### PR TITLE
Insert hidden inputs before file input to appease S3

### DIFF
--- a/jquery.fileupload.js
+++ b/jquery.fileupload.js
@@ -284,12 +284,11 @@
                     .attr('disabled', true)
                     .addClass(settings.namespace + '_disabled');
                 $.each(formData, function (index, field) {
-                    uploadForm.append(
-                        $('<input type="hidden"/>')
-                            .attr('name', field.name)
-                            .val(field.value)
-                            .addClass(settings.namespace + '_form_data')
-                    );
+                    $('<input type="hidden"/>')
+                        .attr('name', field.name)
+                        .val(field.value)
+                        .addClass(settings.namespace + '_form_data')
+                        .insertBefore(fileInput);
                 });
                 input.insertAfter(fileInput);
             },


### PR DESCRIPTION
S3 is picky about the file being the last value in the request. If it's not the last value, it'll reply with a "400 Bad Request".

I simply tweaked `legacyUploadFormDataInit` to insert them before `fileInput` instead of appending to `uploadForm`.
