### PR TITLE
small patch

### DIFF
--- a/jquery.fileupload.js
+++ b/jquery.fileupload.js
@@ -302,7 +302,8 @@
                         index,
                         xhr,
                         uploadSettings,
-                        function () {
+                        function (newSettings) {
+                            $.extend(uploadSettings, newSettings);
                             upload(files, index, xhr, uploadSettings);
                         }
                     );


### PR DESCRIPTION
I was doing sequential uploads (https://github.com/blueimp/jQuery-File-Upload/wiki/Sequential-Uploads) and wanted to change the URL after every upload (to add the newest CouchDB document revision). This allows me to pass in {url: URLWithNewRevision} to the queued upload function when it gets called.
