### PR TITLE
Fixing bug in Internet Explorer around drap-and-drop

### DIFF
--- a/jquery.fileupload.js
+++ b/jquery.fileupload.js
@@ -7,6 +7,7 @@
  *
  * https://blueimp.net
  * http://www.aquantum.de
+ * GitHub: https://github.com/blueimp/jQuery-File-Upload/wiki
  */
 
 /*jslint browser: true */
@@ -467,10 +468,10 @@
                 return false;
             }
             var dataTransfer = e.originalEvent.dataTransfer;
-            if (dataTransfer) {
+            if (dataTransfer && dataTransfer.files) {
                 dataTransfer.dropEffect = dataTransfer.effectAllowed = 'copy';
+                e.preventDefault();
             }
-            e.preventDefault();
         };
 
         this.onDrop = function (e) {


### PR DESCRIPTION
So IE doesn't yet support drag-and-drop, but if options.dragDropSupport == true, then IE will throw an error (on dataTransfer.effectAllowed = 'copy';) if you try to drag anything into it. 

This commit fixes IE and preserves expected drag-and-drop action in IE by opening the file (hence, moving e.preventDefault into the dataTransfer.files check).
