### PR TITLE
CSRF token support.

### DIFF
--- a/jquery.fileupload.js
+++ b/jquery.fileupload.js
@@ -192,6 +192,9 @@
             },
 
             setRequestHeaders = function (xhr, settings, sameDomain) {
+                var token = $('meta[name="csrf-token"]').attr('content');
+                if (token) xhr.setRequestHeader('X-CSRF-Token', token);
+
                 if (sameDomain) {
                     xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                 } else if (settings.withCredentials) {


### PR DESCRIPTION
I've added CSRF (cross-site request forgery token) support, as I needed it for a rails app which uses the  Devise user authentication library.

Looks for a CSRF meta tag on the page, and if found adds a X-CSRF-Token header to the request.

An alternate implementation would be to add an option to either set the csrf token manually, or just one that allows adding arbitrary headers.  If you'd prefer I can work something like one of those up.

Thanks for your great work on the library, it's making file uploads much easier for me!
