### PR TITLE
formData for DELETE requests

### DIFF
--- a/jquery.fileupload-ui.js
+++ b/jquery.fileupload-ui.js
@@ -477,11 +477,13 @@
         _deleteHandler: function (e) {
             e.preventDefault();
             var button = $(this);
+            var fu = e.data.fileupload;
             e.data.fileupload._trigger('destroy', e, {
                 context: button.closest('.template-download'),
                 url: button.attr('data-url'),
+                data: fu.options.formData($("form", fu.element).first()),
                 type: button.attr('data-type'),
-                dataType: e.data.fileupload.options.dataType
+                dataType: fu.options.dataType
             });
         },
         


### PR DESCRIPTION
Here is my answer to Issue #358.  I didn't see an easier way to access the form from the delete handler context.  I also see that you removed the "var fu" reference I was mimicking - I hope you're not offended.
