### PR TITLE
Permission denied error when uploading to another site via an iframe  (IE8)

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -50,7 +50,7 @@
                                 completeCallback(
                                     200,
                                     'success',
-                                    {'iframe': iframe.contents()}
+                                    {'iframe': iframe}
                                 );
                                 // Fix for IE endless progress bar activity bug
                                 // (happens on form submits to iframe targets):


### PR DESCRIPTION
IE is giving me a "permission denied" error when attempting to use jquery file upload to upload to another domain.  This was not an issue with v4.

The crux of the issue is this:  http://stackoverflow.com/questions/1886547/access-is-denied-javascript-error-when-trying-to-access-the-document-object-of

My fix worked for me, however I need your input for the following reasons:
1.  The test suite did not work for me.  It died after test #12, Callbacks: send (0, 1, 1).  It just seems to hang.  This is the case even if I revert my changes.  So please run your test suite against my change.
2.  I don't have enough insider knowledge to know if my fix will break other things.  Please review.

Thanks!
