### PR TITLE
more on permission denied error when uploading to another site via an iframe

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -136,7 +136,12 @@
                 return iframe.text();
             },
             'iframe json': function (iframe) {
-                return $.parseJSON(iframe.text());
+                try {
+                  iframe.text()
+                  return $.parseJSON(iframe.text());
+                } catch(e) {
+                  return;
+                }
             },
             'iframe html': function (iframe) {
                 return iframe.find('body').html();


### PR DESCRIPTION
Related to my original issue: 

[Permission denied error when uploading to another site via an iframe (IE8)](https://github.com/blueimp/jQuery-File-Upload/pull/435)

`iframe.contents()` appears not to be enough to raise an exception in FF.  An error will be raised when the code eventually calls text() to get whatever the response was.  Explicitly calling `iframe.text()` will raise the permissions error.

Also, the response I'm sending to jquery-file-upload is either JSON or an empty response.  As such, `iframe.text()` raises an error on line 139 or jquery.iframe.js.

Please let me know your thoughts, and I'll upload the wiki for sending documents direct to S3.
