### PR TITLE
Fixed erroneous GET in firefox 3.6.

### DIFF
--- a/jquery.fileupload-ui.js
+++ b/jquery.fileupload-ui.js
@@ -276,13 +276,10 @@
                 url = this._createObjectURL(file);
                 
                 if (!url) {
-                  
-                        
                     this._loadFile(file, function (url) {
                         img.prop('src', url);
                     });
-                }
-                else {
+                } else {
                   img = $('<img>').bind('load', function () {
                             $(this).unbind('load');
                             that._revokeObjectURL(url);


### PR DESCRIPTION
Firefox 3.6 was setting the src attribute of the preview image to false, which caused it to issue a GET request to '/false' resulting in a 404.
