### PR TITLE
Confirm dialog for delete handler

### DIFF
--- a/jquery.fileupload-ui.js
+++ b/jquery.fileupload-ui.js
@@ -485,6 +485,9 @@
         },
         
         _deleteHandler: function (e) {
+	    if (!confirm('Delete file?')) {
+		return;
+	    }
             e.preventDefault();
             var button = $(this);
             e.data.fileupload._trigger('destroy', e, {


### PR DESCRIPTION
Hi,

I've added a confirm dialog for the delete button.
I wanted to make this optional, but this.options is not available in the eventHandler methods and I've found no other way to include this, so this is more like a feature request.

Best regards,
schmunk
