### PR TITLE
fix jqXHR object initialization

### DIFF
--- a/jquery.fileupload.js
+++ b/jquery.fileupload.js
@@ -491,7 +491,8 @@
                         that._trigger('send', e, options) !== false &&
                         (that._chunkedUpload(options) || $.ajax(options))) ||
                         that._getXHRPromise(false, options.context, args)
-                    ).done(function (result, textStatus, jqXHR) {
+                    );
+                    jqXHR.done(function (result, textStatus, jqXHR) {
                         that._onDone(result, textStatus, jqXHR, options);
                     }).fail(function (jqXHR, textStatus, errorThrown) {
                         that._onFail(jqXHR, textStatus, errorThrown, options);


### PR DESCRIPTION
The jqXHR objects returned by data.submit() did not contain the abort function and thus could not be cancelled (Chrome 17.0.928.0 dev-m). This commit changes the variable assignment syntax slightly to ensure that the object is initialized properly.
