### PR TITLE
Fix line breaking issue

### DIFF
--- a/jquery.fileupload-ui.js
+++ b/jquery.fileupload-ui.js
@@ -135,8 +135,8 @@
                         $(this).fadeOut(function () {
                             if (data.errorThrown !== 'abort') {
                                 var file = data.files[index];
-                                file.error = file.error || data.errorThrown
-                                    || true;
+                                file.error = file.error || data.errorThrown ||
+                                    true;
                                 that._renderDownload([file])
                                     .css('display', 'none')
                                     .replaceAll(this)

--- a/jquery.fileupload.js
+++ b/jquery.fileupload.js
@@ -405,8 +405,8 @@
                                     total: o.chunkSize
                                 }), o);
                             }
-                            options.uploadedBytes = o.uploadedBytes
-                                += o.chunkSize;
+                            options.uploadedBytes = o.uploadedBytes +=
+                              o.chunkSize;
                         });
                     return jqXHR;
                 });


### PR DESCRIPTION
As Crockford [says](http://javascript.crockford.com/code.html#line length):

> When a statement will not fit on a single line, it may be necessary to break it. Place the break after an operator, ideally after a comma. A break after an operator decreases the likelihood that a copy-paste error will be masked by semicolon insertion.
