### PR TITLE
Fix relative AMD paths.

### DIFF
--- a/js/jquery.fileupload-ip.js
+++ b/js/jquery.fileupload-ip.js
@@ -1,5 +1,5 @@
 /*
- * jQuery File Upload Image Processing Plugin 1.0.4
+ * jQuery File Upload Image Processing Plugin 1.0.5
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2012, Sebastian Tschan
@@ -20,7 +20,7 @@
             'jquery',
             'load-image',
             'canvas-to-blob',
-            './jquery.fileupload.js'
+            './jquery.fileupload'
         ], factory);
     } else {
         // Browser globals:

--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -1,5 +1,5 @@
 /*
- * jQuery File Upload User Interface Plugin 6.6.1
+ * jQuery File Upload User Interface Plugin 6.6.2
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2010, Sebastian Tschan
@@ -20,7 +20,7 @@
             'jquery',
             'tmpl',
             'load-image',
-            './jquery.fileupload-ip.js'
+            './jquery.fileupload-ip'
         ], factory);
     } else {
         // Browser globals:


### PR DESCRIPTION
Requirejs treats module names with file extension as full file paths and try to download ./jquery.fileupload-ip.js which isn’t what we need becase it’s path relative to current page, not jquery.fileupload-ui.js file.
