### PR TITLE
Fix iframe transport to work with older Opera versions

### DIFF
--- a/js/jquery.iframe-transport.js
+++ b/js/jquery.iframe-transport.js
@@ -57,6 +57,16 @@
                         iframe
                             .unbind('load')
                             .bind('load', function () {
+                                // fix for old Opera versions (< 9.6) firing
+                                // additional event on submit to iframe when no
+                                // response has been received yet
+                                try {
+                                    if (iframe.contents().get(0)
+                                            .location == "javascript:false;") {
+                                        return;
+                                    }
+                                } catch (e) {
+                                }
                                 var response;
                                 // Wrap in a try/catch block to catch exceptions thrown
                                 // when trying to access cross-domain iframe contents:


### PR DESCRIPTION
Opera < 9.6 iframe sometimes (always?) triggers premature
onload event right after submit before response was received

This commit should fix it, tested on Opera Linux 9.27 and Opera Linux 9.52
