### PR TITLE
Move from .delegate to .on since confirmed problems occur when plugin is used with jQ 1.7.2

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -597,21 +597,21 @@
             parentWidget.prototype._initEventHandlers.call(this);
             var eventData = {fileupload: this};
             this.options.filesContainer
-                .delegate(
-                    '.start button',
+                .on(
                     'click.' + this.options.namespace,
+                    '.start button',
                     eventData,
                     this._startHandler
                 )
-                .delegate(
-                    '.cancel button',
+                .on(
                     'click.' + this.options.namespace,
+                    '.cancel button',
                     eventData,
                     this._cancelHandler
                 )
-                .delegate(
-                    '.delete button',
+                .on(
                     'click.' + this.options.namespace,
+                    '.delete button',
                     eventData,
                     this._deleteHandler
                 );


### PR DESCRIPTION
I've had to change _initEventHandlers function in jquery.fileupload-ui.js to make use of .on click handler binder instead of .delegate. The later is causing problems in some plugin ui usage scenarios with jQ 1.7.2.
