### PR TITLE
Missing argument 6 for UploadHandler::handle_file_upload()

### DIFF
--- a/server/php/upload.class.php
+++ b/server/php/upload.class.php
@@ -267,7 +267,7 @@ class UploadHandler
             return false;
         }
       	$orientation = intval(@$exif['Orientation']);
-      	if (!in_array($orientation, array(3, 6, 8))) { 
+      	if (!in_array($orientation, array(3, 6, 8))) {
       	    return false;
       	}
       	$image = @imagecreatefromjpeg($file_path);
@@ -290,7 +290,7 @@ class UploadHandler
       	return $success;
     }
 
-    protected function handle_file_upload($uploaded_file, $name, $size, $type, $error, $index) {
+    protected function handle_file_upload($uploaded_file, $name, $size, $type, $error, $index = null) {
         $file = new stdClass();
         $file->name = $this->trim_file_name($name, $type, $index);
         $file->size = intval($size);


### PR DESCRIPTION
The Default upload.class.php doesn't work for me and returns 
`Missing argument 6 for UploadHandler::handle_file_upload() on line 400` when uploading a file in Chrome.
