### PR TITLE
Added code to prevent caching during the DELETE request (Chrome)

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -295,6 +295,7 @@
             destroy: function (e, data) {
                 var that = $(this).data('fileupload');
                 if (data.url) {
+                    data.url = data.url + "?" + new Date().getTime() + Math.random();//prevent browser from returning cached image as the response
                     $.ajax(data);
                     that._adjustMaxNumberOfFiles(1);
                 }


### PR DESCRIPTION
request didn't reach the server, 
Chrome ignored the fact it's a DELETE request and since the image was cached returned the cached image bytes instead of deleting it
I tried to do data.cache = false, but for some reason it didn't work as expected... (I guess it works only with GET requests)
the following is the quickest and dirtiest solution I found, but it will happen to anyone using Chrome and caching those images... 
One of the most elusive bugs I ever encountered :) 
