### PR TITLE
Workaround for Chrome bug that prevents onchange events from receiving the selected files

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -850,7 +850,7 @@
                     fileInput.prop('entries'),
                 files,
                 value;
-            if (entries) {
+            if (entries && entries.length > 0) {
                 return this._handleFileTreeEntries(entries);
             }
             files = $.makeArray(fileInput.prop('files'));


### PR DESCRIPTION
This would prevent users with the bugged Chrome versions from being able to select files using the file input widget. Using drag-n-drop still worked fine.

Ref: http://code.google.com/p/chromium/issues/detail?id=138987
