### PR TITLE
jQuery 1.8 fix for deprecated input selectors

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -963,8 +963,8 @@
         _initSpecialOptions: function () {
             var options = this.options;
             if (options.fileInput === undefined) {
-                options.fileInput = this.element.is('input:file') ?
-                        this.element : this.element.find('input:file');
+                options.fileInput = this.element.is('input[type="file"]') ?
+                        this.element : this.element.find('input[type="file"]');
             } else if (!(options.fileInput instanceof $)) {
                 options.fileInput = $(options.fileInput);
             }


### PR DESCRIPTION
In the new jQuery 1.8 the 'input:file' kind of selectors are deprecated, so it caused bugs.

http://bugs.jquery.com/ticket/9400
