### PR TITLE
Jquery ui - delete not wanted line breaks for already uploaded files

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -56,7 +56,7 @@ ul.nav li {
   float: left;
 }
 td.delete {
-  white-space:nowrap;
+  white-space: nowrap;
 }
 
 /* Fix for IE 6: */


### PR DESCRIPTION
Fix a mini graphical bug visible under Chrome 22 (and may be other versions) where the "Delete" button and the check box were not on the same line for already uploaded files.
