### PR TITLE
Changed split() to preg_split() in upload.class.php

### DIFF
--- a/server/php/upload.class.php
+++ b/server/php/upload.class.php
@@ -665,7 +665,7 @@ class UploadHandler
         // Parse the Content-Range header, which has the following form:
         // Content-Range: bytes 0-524287/2000000
         $content_range = isset($_SERVER['HTTP_CONTENT_RANGE']) ?
-            split('[^0-9]+', $_SERVER['HTTP_CONTENT_RANGE']) : null;
+            preg_split("/[^0-9]+/", $_SERVER['HTTP_CONTENT_RANGE']) : null;
         $size =  $content_range ? $content_range[3] : null;
         $info = array();
         if ($upload && is_array($upload['tmp_name'])) {


### PR DESCRIPTION
split() is deprecated in php 5.3 and throws an E_Deprecated warning when running strict that breaks the chunked uploads.  Switching to preg_split() fixes the issue.
