### PR TITLE
Fix #1841 by using jQuery to get the form action

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -19,7 +19,7 @@ $(function () {
     $('#fileupload').fileupload({
         // Uncomment the following to send cross-domain cookies:
         //xhrFields: {withCredentials: true},
-        url: 'server/php/'
+        url: $('#fileupload').prop('action')
     });
 
     // Enable iframe cross-domain access via redirect option:


### PR DESCRIPTION
The form action was being overriden in `main.js`. This actually gets it from the form allowing for changing it in the form as described in the documentation.
