### PR TITLE
Fixes display of bitrate with long decimal numbers.

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -361,7 +361,7 @@
             if (bits >= 1000) {
                 return (bits / 1000).toFixed(2) + ' kbit/s';
             }
-            return bits + ' bit/s';
+            return bits.toFixed(2) + ' bit/s';
         },
 
         _formatTime: function (seconds) {


### PR DESCRIPTION
When uploading multiple files on Internet Explorer 9, the extended progress bar is updated only after each file has been uploaded. I've add bitrate reports of 0.23242[...] bit/s.

With this pull request I'm making sure that we have the same number of decimals for all bitrate formats.

Thanks for reviewing.
