### PR TITLE
Enable dragging and dropping of text and hyperlinks

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -952,7 +952,7 @@
         },
 
         _onDrop: function (e) {
-            e.preventDefault();
+            this._maybePreventDefault(e);
             var that = this,
                 dataTransfer = e.dataTransfer = e.originalEvent.dataTransfer,
                 data = {};
@@ -972,7 +972,7 @@
             if (dataTransfer) {
                 dataTransfer.dropEffect = 'copy';
             }
-            e.preventDefault();
+            this._maybePreventDefault(e);
         },
 
         _initEventHandlers: function () {
@@ -1021,6 +1021,26 @@
             }
             if (!(options.pasteZone instanceof $)) {
                 options.pasteZone = $(options.pasteZone);
+            }
+        },
+
+        // Prevent default action when dragging and dropping files
+        _maybePreventDefault: function(e) {
+            var tagName = e.target.tagName.toLowerCase(),
+                dataTransfer = e.dataTransfer = e.originalEvent.dataTransfer;
+
+            function containsFiles() {
+                var i;
+                for(i = 0; i < dataTransfer.types.length; i++){
+                    if(dataTransfer.types[i] === "Files") {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            if (containsFiles() || ["textarea", "input"].indexOf(tagName) == -1) {
+                e.preventDefault()
             }
         },
 


### PR DESCRIPTION
This enables dragging and dropping of hyperlinks and plain text to input fields inside the file upload area. Default action over `input` and `textarea` elements is only prevented when `event.dataTransfer` contains files.

How to test/reproduce:
- drag and drop hyperlink from e.g. browser address bar to a text input inside droppable area (say, I have a chat input with file upload functionality)

Current master behavior: Nothing happens.
Expected behavior: Input contains the dragged hyperlink as text.
