### PR TITLE
Hack to work around safari post caching

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -651,6 +651,10 @@
                 pipe,
                 options = that._getAJAXSettings(data),
                 send = function () {
+                    if( $.browser.safari ){
+                        options.url = options.url + '?safari_dont_cache_me=' + ( Math.random().toString().replace(/\./,'') );
+                    }
+                    
                     that._sending += 1;
                     // Set timer for bitrate progress calculation:
                     options._bitrateTimer = new that._BitrateTimer();


### PR DESCRIPTION
Hi, not much of a contribution, sorry for that. We got a lot of complaints from safari users recently not being able to submit more then one picture at a time.

Turned out to be a "bug" in Safari: Safari on IOS6 is caching post requests. This fix worked for us, but it is a revolting hack in the URL to which we're submitting. Spent a lot of hours on this one.

Reproduce:

Safari, latest OSX, using either:

```
  sequentialUploads: > 0
  limitConcurrentUploads: true
```

or piece-by-piece uploading.

Thank you very much for releasing and improving your software!
It is in use by millions of people in belgium!
