### PR TITLE
Helps to upload files in the order they appear in the UI.

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -579,7 +579,13 @@
             this._on(fileUploadButtonBar.find('.start'), {
                 click: function (e) {
                     e.preventDefault();
-                    filesList.find('.start button').click();
+                    filesList.find('.start button').each(function(index) {
+                        // fire upload one file after another with a 500 ms delay inbetween
+                        var button = this;
+                        setTimeout(function() {
+                            button.click();
+                        }, (index * 500));
+                    });
                 }
             });
             this._on(fileUploadButtonBar.find('.cancel'), {


### PR DESCRIPTION
Also keeps parallel requests to the server at bay thus saving server resources.
The approach taken here is not 100 percent reliable but reduces
out of order uploads a lot.

See also https://groups.google.com/forum/#!searchin/jquery-fileupload/appengine/jquery-fileupload/osntyW7yDLg/jRtduHTHw6UJ

I'm not sure if 500 ms delay per upload is the right time - maybe this should be configurable?
I'm seeing the out of order upload behaviour with a `submit` AJAX hook on AppEngine - so this might be the reason I see out of order uploads.

Whatever I think wiring the click() events not to fast is a good thing.
