### PR TITLE
Check for a valid iframe response before trying to access the iframe body's text

### DIFF
--- a/js/jquery.iframe-transport.js
+++ b/js/jquery.iframe-transport.js
@@ -155,16 +155,24 @@
     $.ajaxSetup({
         converters: {
             'iframe text': function (iframe) {
-                return $(iframe[0].body).text();
+                if (iframe) {
+                  return $(iframe[0].body).text();
+                }
             },
             'iframe json': function (iframe) {
-                return $.parseJSON($(iframe[0].body).text());
+                if (iframe) {
+                  return $.parseJSON($(iframe[0].body).text());
+                }
             },
             'iframe html': function (iframe) {
-                return $(iframe[0].body).html();
+                if (iframe) {
+                  return $(iframe[0].body).html();
+                }
             },
             'iframe script': function (iframe) {
-                return $.globalEval($(iframe[0].body).text());
+                if (iframe) {
+                  return $.globalEval($(iframe[0].body).text());
+                }
             }
         }
     });


### PR DESCRIPTION
When the iframe transport is used for a cross-origin upload, the iframe response body canot be accessed from javascript.
