### PR TITLE
Pass isXHRUpload to 'add' callback

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -731,8 +731,9 @@
                 paramNameSlice,
                 fileSet,
                 i;
+            data.isXHRUpload = this._isXHRUpload(options);
             if (!(options.singleFileUploads || limit) ||
-                    !this._isXHRUpload(options)) {
+                    !data.isXHRUpload) {
                 fileSet = [data.files];
                 paramNameSet = [paramName];
             } else if (!options.singleFileUploads && limit) {


### PR DESCRIPTION
Having this field in the add callback data allows the client to do something special when an iframe transport is being used such as show a spinner instead of a progress bar.
