### PR TITLE
Fix jQuery 1.9 serialization issue.

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -33,6 +33,21 @@
     $.support.xhrFileUpload = !!(window.XMLHttpRequestUpload && window.FileReader);
     $.support.xhrFormDataFileUpload = !!window.FormData;
 
+    // The form.elements propHook is added to filter serialized elements
+    // to not include file inputs in jQuery 1.9.0
+    // This hooks directly into jQuery.fn.serializeArray
+    // For more info, see http://bugs.jquery.com/ticket/13306
+    $.propHooks.elements = {
+        get: function(form) {
+            if (jQuery.nodeName(form, "form")) {
+                return jQuery.grep(form.elements, function(elem) {
+                    return !jQuery.nodeName(elem, "input") || elem.type !== "file";
+                });
+            }
+            return null;
+        }
+    };
+
     // The fileupload widget listens for change events on file input fields defined
     // via fileInput setting and paste or drop events of the given dropZone.
     // In addition to the default jQuery Widget methods, the fileupload widget


### PR DESCRIPTION
In jQuery 1.9, jQuery.fn.serializeArray was changed to adhere more to the HTML5 spec. However, once these changes were made, file inputs began to be included. The result is that this adds an extra file parameter to all S3 payloads in jQuery-File-Upload, causing a 400. For other uploads, this may not be big deal, but given S3's strict parameter validation, S3 uploads are not possible without this fix. 

Related on the forums:
https://groups.google.com/forum/#!topic/jquery-fileupload/r0aEXHk22xQ
https://groups.google.com/forum/#!topic/jquery-fileupload/cDc5yTrclkk

Opened jQuery ticket (jQuery will ignore file inputs in 1.9.1):
http://bugs.jquery.com/ticket/13306

Test case:
http://jsbin.com/orurap/1/ (open a console to see the difference between 1.8 and 1.9 serializeArray)
