### PR TITLE
Fix to prevent extra progress callback

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -710,7 +710,7 @@
                         that._getXHRPromise(false, options.context, aborted)) ||
                         that._chunkedUpload(options) || $.ajax(options)
                     ).done(function (result, textStatus, jqXHR, doneOptions) {
-                        that._onDone(result, textStatus, jqXHR, doneOptions);
+                        that._onDone(result, textStatus, jqXHR, doneOptions || options);
                     }).fail(function (jqXHR, textStatus, errorThrown) {
                         that._onFail(jqXHR, textStatus, errorThrown, options);
                     }).always(function (jqXHRorResult, textStatus, jqXHRorError) {


### PR DESCRIPTION
Currently chunked uploading is not passing the updated options to `_onDone`, which causes the test at the beginning to fail (because `options.loaded` and `options.total` are missing), which then causes an extra progress event to be sent with `loaded` == `total * 2`.

By passing the updated options to `_onDone`, everything works as expected.
