### PR TITLE
Added options for customize default error messages

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -485,7 +485,7 @@
         // object and the file that triggered the error.
         _getErrorMessage: function (errorMsg, file){
             if (typeof errorMsg === 'function'){
-                return errorMsg(this, file);
+                return errorMsg(file, this.options);
             } else {
                 return errorMsg;
             }


### PR DESCRIPTION
The text for handling errors like file exceeding maxFileSize where harcoded in the JS and it can't be changed.

Now, when you initialize the fileupload, you can provide a custom message for each restriction.

E.g.

``` javascript
  $('#photos_area').fileupload(
    maxNumberOfFiles: 10,
    maxFileSize: 3000000, // 3 MB
    maxFileSizeError: "File size exceeds the maximum allowed size (3 MB)",
    acceptFileTypes: /(\.|\/)(jpe?g)$/i,
    acceptFileTypesError: "Invalid file format. Only jpeg files are allowed"
  )
```

If you want more customization, the errors can also be functions that receives the file that triggered the error and the options of the fileupload

``` javascript
  $('#photos_area').fileupload(
    maxFileSize: 3000000, // 3 MB
    maxFileSizeError: function(file, options) {
      file.name + " size exceeds the maximum allowed size (" + options.maxFileSize / 1000000 + "MB)"
    }
  )
```

You can personalize `maxFileSizeError`, `minFileSizeError` and `acceptFileTypesError`, but is trivial to add more messages.

If you don't provide a custom message error, the error messages are the plain old messages ("File is too big", "File is too small" and "Filetype not allowed")
