### PR TITLE
Deleting files misleading - Files removed before ajax request is processed

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -328,15 +328,16 @@
                 var that = $(this).data('blueimp-fileupload') ||
                         $(this).data('fileupload');
                 if (data.url) {
-                    $.ajax(data);
+                    $.ajax(data).done(function() {
+                        that._transition(data.context).done(
+                            function () {
+                                $(this).remove();
+                                that._trigger('destroyed', e, data);
+                            }
+                        );
+                    });
                     that._adjustMaxNumberOfFiles(1);
                 }
-                that._transition(data.context).done(
-                    function () {
-                        $(this).remove();
-                        that._trigger('destroyed', e, data);
-                    }
-                );
             }
         },
 


### PR DESCRIPTION
When a user has a lot of files they want to delete, they might check them all and click delete. The delete function will start an ajax request and remove the item from the list. This is misleading, since the ajax request may or may not have completed.

This problem is made worse by browsers limiting the maximum number of simultaneous ajax requests. If I select 10 files and click delete, the files will disappear, representing to me that they are gone. However, if I leave the page immediately following and come back, there will still be four files that didn't complete the ajax request because of the built in browser restrictions.

This commit moves the file inside of the ajax.done function so that it isn't removed until the actual request has been completed.

P.S. First pull / fork ever with github. If I should do something different or better, let me know.
