### PR TITLE
Add Content-Length to requests to send file size

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -362,7 +362,8 @@
             }
             if (!multipart) {
                 options.headers['Content-Disposition'] = 'attachment; filename="' +
-                    encodeURI(file.name) + '"';
+                    encodeURI(file.name) + '";
+                options.headers['Content-Length'] = file.size;
                 options.contentType = file.type;
                 options.data = options.blob || file;
             } else if ($.support.xhrFormDataFileUpload) {
@@ -397,6 +398,7 @@
                     if (options.blob) {
                         options.headers['Content-Disposition'] = 'attachment; filename="' +
                             encodeURI(file.name) + '"';
+                        options.headers['Content-Length'] = file.size;
                         formData.append(paramName, options.blob, file.name);
                     } else {
                         $.each(options.files, function (index, file) {


### PR DESCRIPTION
Fix for issue #2227. Sends a `Content-Length` header with PUT requests and sends a `Content-Length` header in each multipart file part.
