### PR TITLE
added higher memory_limit default

### DIFF
--- a/server/php/index.php
+++ b/server/php/index.php
@@ -11,5 +11,6 @@
  */
 
 error_reporting(E_ALL | E_STRICT);
+ini_set('memory_limit', '64M'); // increase to handle large files
 require('UploadHandler.php');
 $upload_handler = new UploadHandler();


### PR DESCRIPTION
`memory_limit` being set too low was causing my uploads to fail silently
