### PR TITLE
NS_ERROR_CANNOT_CONVERT_DATA on form data submition (IE8 / FF9-10)

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -436,7 +436,7 @@
                     } else {
                         formData = new FormData();
                         $.each(this._getFormData(options), function (index, field) {
-                            formData.append(encodeURI(field.name), encodeURI(field.value));
+                            formData.append(field.name, encodeURI(field.value));
                         });
                     }
                     if (options.blob) {


### PR DESCRIPTION
When I try to upload multipart mixed (JSON + files), I have this error : NS_ERROR_CANNOT_CONVERT_DATA.

After investigation, I found that the problem came from the data submition when field.value is an array.
