### PR TITLE
Fixed angular module when used into a custom directive.

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -38,10 +38,12 @@
         .provider('fileUpload', function () {
             var scopeApply = function () {
                     var scope = angular.element(this)
-                        .fileupload('option', 'scope')();
-                    if (!scope.$$phase) {
+                        .fileupload('option', 'scope')(),
+                        $timeout = angular.injector(['ng'])
+                        .get('$timeout');
+                    $timeout(function () {
                         scope.$apply();
-                    }
+                    });
                 },
                 $config;
             $config = this.defaults = {


### PR DESCRIPTION
Do not rely on the $$phase variable anymore.

Since fileUpload is created as a provider, the $timeout service has to be invoked via angular.injector.

Fix for this issue:
https://github.com/blueimp/jQuery-File-Upload/issues/2453
