### PR TITLE
proposed fix: replacing implicit bool coercion w/ $.type(numberOfFiles)

### DIFF
--- a/js/jquery.fileupload-validate.js
+++ b/js/jquery.fileupload-validate.js
@@ -85,7 +85,7 @@
                     settings = this.options,
                     file = data.files[data.index],
                     numberOfFiles = settings.getNumberOfFiles();
-                if (numberOfFiles && $.type(options.maxNumberOfFiles) === 'number' &&
+                if ($.type(numberOfFiles) === 'number' && $.type(options.maxNumberOfFiles) === 'number' &&
                         numberOfFiles + data.files.length > options.maxNumberOfFiles) {
                     file.error = settings.i18n('maxNumberOfFiles');
                 } else if (options.acceptFileTypes &&


### PR DESCRIPTION
_(apologies in advance, this is my very first pull request)_

If numberOfFiles === 0,  then the "maxNumberOfFiles" validation check
never fails, even if data.files.length exceeds the max (because 0 is
'falsy', the rest of the expression evaluates to false).   My proposed
fix is to  check the type of numberOfFiles.
