### PR TITLE
Work on a copy of the headers in _initXHRData

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -399,7 +399,7 @@
                 // Ignore non-multipart setting if not supported:
                 multipart = options.multipart || !$.support.xhrFileUpload,
                 paramName = options.paramName[0];
-            options.headers = options.headers || {};
+            options.headers = $.extend({}, options.headers || {});
             if (options.contentRange) {
                 options.headers['Content-Range'] = options.contentRange;
             }


### PR DESCRIPTION
If someone passes a "headers" options to fileupload(), this object get overwritten across multiple files upload because the same object is being re-used.
