### PR TITLE
Add option to automatically resume failed chunks up to maxRetries times ...

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -132,6 +132,8 @@
             bitrateInterval: 500,
             // By default, uploads are started automatically when adding files:
             autoUpload: true,
+            // Number of times to retry a chunked PUT request. 0 to disable.
+            maxRetries: 0,
 
             // Error and info messages:
             messages: {
@@ -691,7 +693,8 @@
                 dfd = $.Deferred(),
                 promise = dfd.promise(),
                 jqXHR,
-                upload;
+                upload,
+                retries = 0;
             if (!(this._isXHRUpload(options) && slice && (ub || mcs < fs)) ||
                     options.data) {
                 return false;
@@ -749,6 +752,8 @@
                         o.jqXHR = jqXHR;
                         that._trigger('chunkdone', null, o);
                         that._trigger('chunkalways', null, o);
+                        retries = 0;
+
                         if (ub < fs) {
                             // File upload not yet complete,
                             // continue with the next chunk:
@@ -766,10 +771,15 @@
                         o.errorThrown = errorThrown;
                         that._trigger('chunkfail', null, o);
                         that._trigger('chunkalways', null, o);
-                        dfd.rejectWith(
-                            o.context,
-                            [jqXHR, textStatus, errorThrown]
-                        );
+
+                        if (++retries > options.maxRetries) {
+                            dfd.rejectWith(
+                                o.context,
+                                [jqXHR, textStatus, errorThrown]
+                            );
+                        } else {
+                            upload();
+                        }
                     });
             };
             this._enhancePromise(promise);


### PR DESCRIPTION
...before failing the file in progress.

This small patch allows you to specify maxRetries in the options object which will retry a chunk (PUT) request that many times before causing the entire upload to fail.

In our use-case it adds resilience to uploads where the receiving server may restart services less-than-gracefully, but is useful in the case of a poor network connection combined with a small chunk size.

It obviously only affects chunked uploads.
