### PR TITLE
(AngularJS) Fix $scope initialization respecting scope hierarchy

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -224,7 +224,9 @@
                     }
                 };
                 $scope.disabled = !$window.jQuery.support.fileInput;
-                $scope.queue = $scope.queue || [];
+                if ($scope.queue === undefined) {
+                    $scope.queue = [];
+                }
                 $scope.clear = function (files) {
                     var queue = this.queue,
                         i = queue.length,


### PR DESCRIPTION
Original code is not respecting `$scope` hierarchy - it creates `queue` property even if that property is defined in parent `$scope`. That way it is impossible to manipulate `queue` in parent code (controller or directive) that controls `<file-upload>` directive.

If anything is unclear, I can provide live demo.
