### PR TITLE
Fix IE prior to 10 - unable to access server response data in callbacks

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -289,12 +289,31 @@
                         return;
                     }
                     if (data.dataType &&
-                            data.dataType.indexOf('json') === data.dataType.length - 4) {
+                        typeof JSON !== 'undefined' &&
+                        (data.dataType.indexOf('json') === data.dataType.length - 4||
+                         data.dataType.indexOf('plain') === data.dataType.length - 5 ||
+                         data.dataType.indexOf('html') === data.dataType.length - 4 )
+                        ) {
                         try {
                             data.result = angular.fromJson(data.jqXHR.responseText);
                         } catch (ignore) {}
                     }
-                }).on([
+                }).on('fileuploaddone', function (e, data) {
+                    if (data.errorThrown === 'abort') {
+                        return;
+                    }
+                    if (data.dataType &&
+                        typeof JSON !== 'undefined' &&
+                        (data.dataType.indexOf('json') === data.dataType.length - 4||
+                         data.dataType.indexOf('plain') === data.dataType.length - 5 ||
+                         data.dataType.indexOf('html') === data.dataType.length - 4 )
+                        ) {
+                        try {
+                            data.result = angular.fromJson(data.jqXHR.responseText);
+                        } catch (ignore) {}
+                    }
+                })
+                .on([
                     'fileuploadadd',
                     'fileuploadsubmit',
                     'fileuploadsend',


### PR DESCRIPTION
Added support for other data types then xxx/json(text/plain and text/html), fixes issues with IE prior to 10.

please refer to:
https://github.com/blueimp/jQuery-File-Upload/wiki/Setup#content-type-negotiation

Some prefer to set the data type to text\plain, and some to text\html to prevent from IE to try and save application\json data that outputs into the iframe.
This patch supports both cases.
