### PR TITLE
Allow "options.acceptFileTypes" to be a string

### DIFF
--- a/js/jquery.fileupload-validate.js
+++ b/js/jquery.fileupload-validate.js
@@ -84,6 +84,11 @@
                 var dfd = $.Deferred(),
                     settings = this.options,
                     file = data.files[data.index];
+                    
+                if ($.type(options.acceptFileTypes) === 'string' && options.acceptFileTypes.length) {
+                    options.acceptFileTypes = new RegExp(options.acceptFileTypes);
+                }
+
                 if ($.type(options.maxNumberOfFiles) === 'number' &&
                         (settings.getNumberOfFiles() || 0) + data.files.length >
                             options.maxNumberOfFiles) {


### PR DESCRIPTION
Hi,

I'm implementing the uploader in my AngularJS app and came into tiny problem where I define all the uploader's options in the template:

``` html
<div file-upload="{
    'method' : 'put',
    'url' : '/user/avatar/',
    'autoUpload' : true,
    'maxFileSize' : 5242880,
    'acceptFileTypes' : /(\.|\/)(gif|jpe?g|png)$/i
}">
....
</div>
```

Obviously, the `acceptFileTypes` option defined like this is not a valid `RegExp` object - Angular actually throws an error:

```
Error: [$parse:lexerr] Lexer Error: Unexpected next character  at columns 313-313 [\] in expression [{
    'method' : 'put',
    'url' : '/user/avatar/',
    'autoUpload' : true,
    'maxFileSize' : 5242880,
    'acceptFileTypes' : /(\.|\/)(gif|jpe?g|png)$/i
}].
```

I know that I could define the options hash in the controller (like the demo does), but I wanted to keep the controller as small as possible.

Therefore I've made a tiny tweak that allows the `acceptFileTypes` option to be a string that will get converted into `RegExp` object (if it's not empty), so then I can use it like:

``` html
<div file-upload="{
   ...
    'acceptFileTypes' : '(\.|\/)(gif|jpe?g|png)$'
}">
....
</div>
```
