### PR TITLE
Default the file type to octetstream when unspecified

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -429,7 +429,7 @@
                     encodeURI(file.name) + '"';
             }
             if (!multipart) {
-                options.contentType = file.type;
+                options.contentType = file.type || 'application/octet-stream';
                 options.data = options.blob || file;
             } else if ($.support.xhrFormDataFileUpload) {
                 if (options.postMessage) {


### PR DESCRIPTION
In the case where the host browser cannot deduce the file type, the default value of the content-type should be application/octet-stream, otherwise the request may end up with an invalid Content-Type header.
