### PR TITLE
New option for transliteration filenames

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -46,6 +46,7 @@ class UploadHandler
             'user_dirs' => false,
             'mkdir_mode' => 0755,
             'param_name' => 'files',
+			'transliterate_names' => false,
             // Set the following option to 'POST', if your server does not support
             // DELETE requests. This is a parameter sent to the client:
             'delete_type' => 'DELETE',
@@ -455,7 +456,15 @@ class UploadHandler
             preg_match('/^image\/(gif|jpe?g|png)/', $type, $matches)) {
             $name .= '.'.$matches[1];
         }
-        return $name;
+        
+		// translit unicode names
+		// Notice! Depend on the bundled 'intl' (Internationalization extension) package; PHP >= 5.4.0, PECL intl >= 2.0.0
+		// See: http://www.php.net/manual/transliterator.transliterate.php
+		// or PHP >= 5.2.4 with PECL version of 'intl'
+		// See: http://pecl.php.net/package/intl
+		if ($this->options['transliterate_names'] and extension_loaded("intl")) $name = transliterator_transliterate('Any-Latin; Latin-ASCII', $name);
+		
+		return $name;
     }
 
     protected function get_file_name($name,
@@ -993,6 +1002,7 @@ class UploadHandler
     protected function handle_file_upload($uploaded_file, $name, $size, $type, $error,
             $index = null, $content_range = null) {
         $file = new stdClass();
+		$file->origName = htmlentities($name, ENT_QUOTES, "UTF-8"); // sanitizeHTML
         $file->name = $this->get_file_name($name, $type, $index, $content_range);
         $file->size = $this->fix_integer_overflow(intval($size));
         $file->type = $type;


### PR DESCRIPTION
It resolve problem of 'garbage' filenames at saving of files with
non-latin, unicode names (i.e. in cyrillic) on Win-hosts.
Also field 'origName' (original filename sent from client) for JSON
response are added.
option: 'transliterate_names' (false by deafult)
