### PR TITLE
Apply options limitMultiFileUploads AND limitMultiFileUploadSize, check for options.paramName

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -980,7 +980,8 @@
                     batchSize += files[i].size + overhead;
                     if (i + 1 === filesLength ||
                             (batchSize + files[i + 1].size + overhead) >
-                            limitSize) {
+                            limitSize ||
+                            (limit && i + 1 - j >= limit)) {
                         fileSet.push(files.slice(j, i + 1));
                         paramNameSlice = paramName.slice(j, i + 1);
                         if (!paramNameSlice.length) {


### PR DESCRIPTION
Apply option limitMultiFileUploads even when limitMultiFileUploadSize is defined.
Ensure neither limit is exceeded when uploading.

Use option paramName if it is a string. No longer assume it is an array.
