### PR TITLE
Use Exif Data to check the image type, Do not rely on extention

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -613,7 +613,25 @@ class UploadHandler
         }
         list($file_path, $new_file_path) =
             $this->get_scaled_image_file_paths($file_name, $version);
-        $type = strtolower(substr(strrchr($file_name, '.'), 1));
+        if (function_exists('exif_imagetype')) {
+          //use the signature of the file 
+          switch(exif_imagetype($file_path)){
+            case IMAGETYPE_JPEG:
+              $type = 'jpg';
+              break;
+            case IMAGETYPE_PNG:
+              $type = 'png';
+              break;
+            case IMAGETYPE_GIF:
+              $type = 'gif';
+              break;
+            default:
+              $type = '';
+          }
+        }else {
+          //use the extention;
+          $type = strtolower(substr(strrchr($file_name, '.'), 1));
+        }
         switch ($type) {
             case 'jpg':
             case 'jpeg':


### PR DESCRIPTION
Use the file signature where available rather than the file name. Sometimes images can be displayed with the wrong extension and may go unnoticed such as a jpg renamed to a gif or vise versa 

This PR allows the image to resize these misnamed files. 
