### PR TITLE
FileDestroy don't update file variable(fix)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -69,32 +69,37 @@
         .controller('FileDestroyController', [
             '$scope', '$http',
             function ($scope, $http) {
-                var file = $scope.file,
+                var file,
                     state;
-                if (file.url) {
-                    file.$state = function () {
-                        return state;
-                    };
-                    file.$destroy = function () {
-                        state = 'pending';
-                        return $http({
-                            url: file.deleteUrl,
-                            method: file.deleteType
-                        }).then(
-                            function () {
-                                state = 'resolved';
+                $scope.$watch('file', function() {
+                    if(this.last){
+                        file = this.last //Update File var
+                        if (file.url) {
+                            file.$state = function () {
+                                return state;
+                            };
+                            file.$destroy = function () {
+                                state = 'pending';
+                                return $http({
+                                    url: file.deleteUrl,
+                                    method: file.deleteType
+                                }).then(
+                                    function () {
+                                        state = 'resolved';
+                                        $scope.clear(file);
+                                    },
+                                    function () {
+                                        state = 'rejected';
+                                    }
+                                );
+                            };
+                        } else if (!file.$cancel && !file._index) {
+                            file.$cancel = function () {
                                 $scope.clear(file);
-                            },
-                            function () {
-                                state = 'rejected';
-                            }
-                        );
-                    };
-                } else if (!file.$cancel && !file._index) {
-                    file.$cancel = function () {
-                        $scope.clear(file);
-                    };
-                }
+                            };
+                        }
+                    }
+                });
             }
         ]);
 


### PR DESCRIPTION
After I have migrated to latest AngularJS version 1.2.6 the FileDestroyController don't update after file object proccessed by the jquery.fileupload-angular.js ( create objects: file.url, file.$cancel, etc). To resume, the file var was changed just one time when the controllers were loaded.

After some tests I pretty sure its about the new way how isolate scope and interpolation priorities works now. To solve it I just put a $watch to check all changes on $scope.file object.

More info may you can se at: http://docs.angularjs.org/guide/migration

If you have another way please let me know to update my codes its just one way to solve this minor issue.

Thanks.
