### PR TITLE
Remove the image file when there is an error

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -1012,10 +1012,12 @@ class UploadHandler
             case 1:
                 $file->error = 'Failed to create scaled version: '
                     .$failed_versions[0];
+                unlink($file_path); 
                 break;
             default:
                 $file->error = 'Failed to create scaled versions: '
                     .implode($failed_versions,', ');
+                    unlink($file_path); 
         }
         // Free memory:
         $this->destroy_image_object($file_path);


### PR DESCRIPTION
When the script experience an error dealing with the uploaded image file (scaling, etc) it should be able to clean out before exiting, that is, unlinking the file to save space.
