### PR TITLE
Added destroyfailed event

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -371,7 +371,9 @@
                     };
                 if (data.url) {
                     data.dataType = data.dataType || that.options.dataType;
-                    $.ajax(data).done(removeNode);
+                    $.ajax(data).done(removeNode).fail(function () {
+                        that._trigger('destroyfailed', e, data);
+                    });
                 } else {
                     removeNode();
                 }


### PR DESCRIPTION
Added possibility to inform user about failed deletes.

to be used with:
$('#fileupload').on('fileuploaddestroyfailed', function (e, data) {/\* ... */})
