### PR TITLE
Always clear fileUploadPreview directive element on preview change

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -195,7 +195,7 @@
         })
 
         // The FileUploadController initializes the fileupload widget and
-        // provides scope methods to control the File Upload functionality: 
+        // provides scope methods to control the File Upload functionality:
         .controller('FileUploadController', [
             '$scope', '$element', '$attrs', '$window', 'fileUpload',
             function ($scope, $element, $attrs, $window, fileUpload) {
@@ -377,8 +377,9 @@
                 $scope.$watch(
                     $attrs.fileUploadPreview + '.preview',
                     function (preview) {
+                        $element.empty();
                         if (preview) {
-                            $element.empty().append(preview);
+                            $element.append(preview);
                         }
                     }
                 );


### PR DESCRIPTION
I have a common use case in which I am only letting the user upload one image file and I am showing a preview with the `fileUploadPreview` angular directive.

If the user selects a good image file, it appears in the DOM, but then if the user changes the file to a text file, for example, which has no preview, the directive needs to clear out the preview element because otherwise it will still contain the (stale) preview from the original image file.
