### PR TITLE
Fix firefox issue with jquery file upload

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -48,8 +48,8 @@
     $.support.xhrFormDataFileUpload = !!window.FormData;
 
     // Detect support for Blob slicing (required for chunked uploads):
-    $.support.blobSlice = window.Blob && (Blob.prototype.slice ||
-        Blob.prototype.webkitSlice || Blob.prototype.mozSlice);
+    $.support.blobSlice = window.Blob && (!Blob.prototype && (new Blob()).slice) ||
+        (Blob.prototype.slice || Blob.prototype.webkitSlice || Blob.prototype.mozSlice);
 
     // The fileupload widget listens for change events on file input fields defined
     // via fileInput setting and paste or drop events of the given dropZone.


### PR DESCRIPTION
In the context of a Firefox add on, window.Blob.prototype is undefined,
probably for security reasons. Instead of accessing it directly, we construct
an instance of Blob and use its function definition.
