### PR TITLE
Fixed calculation of filesize in bytes instead of bits.

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -415,13 +415,17 @@
             if (typeof bytes !== 'number') {
                 return '';
             }
-            if (bytes >= 1000000000) {
-                return (bytes / 1000000000).toFixed(2) + ' GB';
+
+            var prefixes = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'],
+                result = bytes,
+                index = 0;
+
+            while (result > 1024 && index < prefixes.length) {
+                result = result / 1024;
+                index++;
             }
-            if (bytes >= 1000000) {
-                return (bytes / 1000000).toFixed(2) + ' MB';
-            }
-            return (bytes / 1000).toFixed(2) + ' KB';
+
+            return result.toFixed(2) + prefixes[index] + 'B';
         },
 
         _formatBitrate: function (bits) {


### PR DESCRIPTION
The ui plugin calculated filesizes based on bits ( 1000 in a Kb ) instead of bytes ( 1024 in a Kb ).

This fixes that.
