### PR TITLE
Additional attribute "totalSize" response on chunked files

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -1023,6 +1023,10 @@ class UploadHandler
         $file->name = $this->get_file_name($uploaded_file, $name, $size, $type, $error,
             $index, $content_range);
         $file->size = $this->fix_integer_overflow(intval($size));
+        if (is_array($content_range))
+            $file->totalSize = $content_range[3];
+        else
+            $file->totalSize = $file->size;        
         $file->type = $type;
         if ($this->validate($uploaded_file, $file, $error, $index)) {
             $this->handle_form_data($file, $index);


### PR DESCRIPTION
This totalSize attribute helps comparing later if the current file chunk is the last one.
So if we need to insert the file record in a database, we do it only once, at the last chunk burst.
