### PR TITLE
updating options to be loadImage.scale compatible

### DIFF
--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -207,6 +207,8 @@
                     }
                 }
                 if (img) {
+                    // JavaScript-Load-Image expects :crop option rather :imageCrop
+                    options.crop = options.imageCrop;
                     resolve(loadImage.scale(img, options));
                     return dfd.promise();
                 }


### PR DESCRIPTION
The issue appears when using `processQueue` to upload multiple image resolutions.
When using `imageCrop` option, the image are just scaled, not cropped.

```
{
  action: 'resizeImage',
  maxWidth:  cfg.photos.width,
  maxHeight: cfg.photos.width,
  imageCrop: true
}
```

That's because JavaScript-Load-Image is using `crop` option and jQuery-File-Upload is sending `imageCrop` option instead.
