### PR TITLE
Throwing custom event for errors occurred while adding a file

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -121,6 +121,7 @@
                                 $(this).find('.error').text(error);
                             }
                         });
+                        that._trigger('adderror', e, data);		//	Added custom event to check whether any error has occured while adding the file.
                     }
                 });
             },


### PR DESCRIPTION
// Line 124: 
that._trigger('customnperror', e, data);

/**
In this plugin we can set various conditions/restrictions on file upload (e.g. acceptFileTypes, maxFileSize, maxNumberOfFiles, etc..)
Whenever a file is added, an event is fired "fileuploadadd" and once the file is added successfully another event is fired "fileuploadadded".
However, when a file is added and it fails one of these condition/restriction (e.g. user tries to upload 2GB file, or text file instead of an image), there is no way find out programatically that this has occurred.
While uploading a file if an error occurs then I have added a code to throw custom error named "adderror", so that we can bind this event and track errors.
**/
