### PR TITLE
Update jquery.fileupload-validate.js

### DIFF
--- a/js/jquery.fileupload-validate.js
+++ b/js/jquery.fileupload-validate.js
@@ -83,7 +83,7 @@
                 }
                 var dfd = $.Deferred(),
                     settings = this.options,
-                    file = data.files[data.index],
+                    file = data.originalFiles[data.index],
                     numberOfFiles = settings.getNumberOfFiles();
                 if (numberOfFiles && $.type(options.maxNumberOfFiles) === 'number' &&
                         numberOfFiles + data.files.length > options.maxNumberOfFiles) {


### PR DESCRIPTION
This helps validation work more accurate. I don't know why but data.files[data.index].size is always greater then data.originalFiles[data.index].size so the validation get incorrect. I set the maxFilesize = 5MB and try to upload a 4.5MB file but it didn't work. Then I finally figured it out: the retrieved file size become 7MB !
Thanks for making such awesome plugin.
