### PR TITLE
Allow aborting of jqXHR through promise.abort

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1401,7 +1401,8 @@
                                 return;
                             }
                             data.files = files;
-                            jqXHR = that._onSend(null, data).then(
+                            jqXHR = that._onSend(null, data);
+                            jqXHR.then(
                                 function (result, textStatus, jqXHR) {
                                     dfd.resolve(result, textStatus, jqXHR);
                                 },


### PR DESCRIPTION
The jqXHR object contained in the promise is overwritten by a promise object lacking an abort method via chaining `_onSend().then`.

Instead, jqXHR should be retained as a jqXHR even though the promise methods can be attached to it.

Try using:

```
$("input").fileUpload().fileupload("send" {files: element}).abort()
```

to get an error that the `abort` method does not exist in this context.
