### PR TITLE
Pass originalData to processQueue function

### DIFF
--- a/js/jquery.fileupload-process.js
+++ b/js/jquery.fileupload-process.js
@@ -78,7 +78,8 @@
                     return that.processActions[settings.action].call(
                         that,
                         data,
-                        settings
+                        settings,
+                        originalData
                     );
                 };
                 chain = chain.pipe(func, settings.always && func);


### PR DESCRIPTION
I am trying to use the processQueue to modify the URL parameter. This is not possible with the data object passed, the originalData object needs to be used.

For example, in my process function I have an AJAX call which gets the endpoint based on the selected file. It then manipulates the data object like so.

```
originalData.url=ajaxData.instructions.url;
originalData.paramName=ajaxData.instructions.filefield;
originalData.formData=ajaxData.instructions.variables;
originalData.serviceInfo=ajaxData.service;
```

It works if I run this code in the "add" callback, however the processQueue seems to be the more correct way to accomplish this.
