### PR TITLE
On replaceFileInput store a reference to the new input

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1015,7 +1015,7 @@
             return result;
         },
 
-        _replaceFileInput: function (input) {
+        _replaceFileInput: function (input, data) {
             var inputClone = input.clone(true);
             $('<form></form>').append(inputClone)[0].reset();
             // Detaching allows to insert the fileInput on another form
@@ -1023,6 +1023,8 @@
             input.after(inputClone).detach();
             // Avoid memory leaks with the detached file input:
             $.cleanData(input.unbind('remove'));
+            // Add a reference to the new cloned file input element
+            data.replacedFileInput=inputClone;
             // Replace the original file input element in the fileInput
             // elements set with the clone, which has been copied including
             // event handlers:
@@ -1187,7 +1189,7 @@
             this._getFileInputFiles(data.fileInput).always(function (files) {
                 data.files = files;
                 if (that.options.replaceFileInput) {
-                    that._replaceFileInput(data.fileInput);
+                    that._replaceFileInput(data.fileInput, data);
                 }
                 if (that._trigger(
                         'change',


### PR DESCRIPTION
Store the new cloned file input in the data as "replacedFileInput"

Test for it with

```
data.replacedFileInput || data.fileInput
```

I propose this because I am using the file upload for global uploads and for uploads in different areas. I wanted to be able to trace back which input was used and where it was used. But since the original is the one referenced in the data, it is no longer in the document.
