### PR TITLE
Android 4+ bug : use of JpegEncoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ The jQuery Iframe Transport is required for [browsers without XHR file upload su
 * [JavaScript Templates engine](https://github.com/blueimp/JavaScript-Templates) v. 2.5.3+
 * [JavaScript Load Image library](https://github.com/blueimp/JavaScript-Load-Image) v. 1.11.0+
 * [JavaScript Canvas to Blob polyfill](https://github.com/blueimp/JavaScript-Canvas-to-Blob) v. 2.1.0+
+* [JavaScript Jpeg Encoder](https://github.com/owencm/javascript-jpeg-encoder)
 * [blueimp Gallery](https://github.com/blueimp/Gallery) v. 2.12.0+
 * [Bootstrap CSS framework](http://getbootstrap.com/) v. 3.0.0+
 * [Glyphicons](http://glyphicons.com/)
 
 The JavaScript Templates engine is used to render the selected and uploaded files for the Basic Plus UI and jQuery UI versions.
 
-The JavaScript Load Image library and JavaScript Canvas to Blob polyfill are required for the image previews and resizing functionality.
+The JavaScript Load Image library and JavaScript Canvas to Blob polyfill are required for the image previews and resizing functionality. For Android 4+, the Javascript Jpeg Encoder can be included to avoid the toDataUrl bug (always returning png)
 
 The blueimp Gallery is used to display the uploaded images in a lightbox.
 

--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -155,7 +155,8 @@
                 if (($.type(options.maxFileSize) === 'number' &&
                             file.size > options.maxFileSize) ||
                         (options.fileTypes &&
-                            !options.fileTypes.test(file.type)) ||
+                            !options.fileTypes.test(file.type) &&
+                            !file.type=="") ||
                         !loadImage(
                             file,
                             function (img) {
@@ -232,6 +233,17 @@
                     data.canvas.toBlob(
                         function (blob) {
                             if (!blob.name) {
+                                if ((file.type !== blob.type) && window.dataURLtoBlob && (typeof JPEGEncoder !== 'undefined' )) {
+                                    var encoder = new JPEGEncoder();
+                                    var quality=options.quality;
+                                    if (! quality) {
+                                        quality=90;
+                                    }
+                                    var imageUrl = encoder.encode(data.canvas.getContext('2d').getImageData(0, 0, data.canvas.width, data.canvas.height), quality);
+                                    blob = window.dataURLtoBlob(imageUrl);
+                                    delete data.imageHead;
+                                }
+
                                 if (file.type === blob.type) {
                                     blob.name = file.name;
                                 } else if (file.name) {


### PR DESCRIPTION
.toDataUrl always return png on Android, and file.type="". To convert
the resized canvas to jpeg, we use JpegEncoder.

More info on :
http://ghinda.net/jpeg-blob-ajax-android/

With my other pull request pending on DarrenInWood/Jquery-File-Upload (still to migrate in separate files), it is now possible to resize and post images on Android 4+
