### PR TITLE
Add error message for unknown errors

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -63,6 +63,7 @@
             // option of the $.ajax upload requests:
             dataType: 'json',
             
+            // Error and info messages:
             messages: {
                 unknownError: 'Unknown error'  
             },


### PR DESCRIPTION
Currently the `fail` option sets `file.error = true` when an unknown error occurs (eg: restart the web server during upload) so it is not possible to change or translate the error message, and in any case true was not a very good error message :)
