### PR TITLE
FF text disappear on tabbing on button fix

### DIFF
--- a/css/jquery.fileupload.css
+++ b/css/jquery.fileupload.css
@@ -21,7 +21,7 @@
   margin: 0;
   opacity: 0;
   -ms-filter: 'alpha(opacity=0)';
-  font-size: 200px;
+  font-size: 20px;
   direction: ltr;
   cursor: pointer;
 }


### PR DESCRIPTION
on Firefox when tabbing (keyboard user) onto the file-input-button the text on the button disappear. 
change the font-size to 20px fixe the issue and still behaves the same on other browser
NOTE: Tabbing + enter on IE does not open the explorer window
