### PR TITLE
Add X-Requested-With: IFrame to iframe transport

### DIFF
--- a/js/jquery.iframe-transport.js
+++ b/js/jquery.iframe-transport.js
@@ -119,6 +119,13 @@
                                     .val(field.value)
                                     .appendTo(form);
                             });
+                            // Add a hidden `X-Requested-With` field with the value `IFrame` to the
+                            // form, to help server-side code to determine that the upload happened
+                            // through this transport.
+                            $('<input type="hidden"/>')
+                                .prop('name', 'X-Requested-With')
+                                .val('IFrame')
+                                .appendTo(form);
                         }
                         if (options.fileInput && options.fileInput.length &&
                                 options.type === 'POST') {


### PR DESCRIPTION
This patch adds a parameter `X-Requested-With=IFrame` to file uploads via the iframe transport.

The patch is taken from the jquery-fileupload-rails gem, which uses the header to detect iframe transport uploads in server middleware. Having this upstream would allow to separate the rails middleware from the js library which would make upgrading the assets much easier.
