### PR TITLE
Add new callback when addition of a file fails

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -124,6 +124,7 @@
                             var error = data.files[index].error;
                             if (error) {
                                 $(this).find('.error').text(error);
+                                that._trigger('addedfailed', e, data);
                             }
                         });
                     }


### PR DESCRIPTION
Introduce a new callback for the ui version which is triggered when the addition of a files fails.
It is useful in combination with the validate plugin to have more control over the ui when the validation fails
