### PR TITLE
Proxy/Balancer: HTTPS was not recognized

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -181,7 +181,9 @@ class UploadHandler
     }
 
     protected function get_full_url() {
-        $https = !empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'on') === 0;
+        
+        $https = (!empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'on') === 0) 
+            || (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0 );
         return
             ($https ? 'https://' : 'http://').
             (!empty($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'].'@' : '').


### PR DESCRIPTION
Fix for #3322

Request -- (https) --> Balancer -- (http) --> Worker

Then the following isn't available with the worker: $_SERVER['HTTPS'] == 'on'
So.. delete link will be always http, you also have to check: $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'
