### PR TITLE
dropZone fix for IE10+ compatibility

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1260,7 +1260,8 @@
             if (this._isXHRUpload(this.options)) {
                 this._on(this.options.dropZone, {
                     dragover: this._onDragOver,
-                    drop: this._onDrop
+                    drop: this._onDrop,
+                    dragenter: function ignoreDrag(e) { e.preventDefault(); } //IE10+
                 });
                 this._on(this.options.pasteZone, {
                     paste: this._onPaste


### PR DESCRIPTION
Prevent default also on "dragenter" event so it can work with IE10+

Change tested (and working) on:
     IE10 (doesn't work with IE9 and lower)
     Chrome 36.0.1985.143 m
     Firefox 31.
