### PR TITLE
set pasteZone to null as default

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -86,11 +86,11 @@
             dropZone: $(document),
             // The paste target element(s), by the default the complete document.
             // Set to null to disable paste support:
-            pasteZone: $(document),
+            pasteZone: $(null),
             // The file input field(s), that are listened to for change events.
             // If undefined, it is set to the file input fields inside
             // of the widget element on plugin initialization.
-            // Set to null to disable the change listener.
+            // Set to document to enable pasting on the whole page.
             fileInput: undefined,
             // By default, the file input field is replaced with a clone after
             // each input field change event. This is required for iframe transport


### PR DESCRIPTION
I just want to propose to not have this activated per default. It led to some pretty nasty behaviour in combination with other form elements.

Here's the scenario:

We have a page where there are other (text-) input elements besides the fileupload.
Our users copy textual data from Excel to these text inputs. Excel automagically creates images of the copied cells in the clipboard.

So every time someone pastes s.th. from Excel, the image in the form on that page, gets overwritten with an image of the copied content.
