### PR TITLE
js: use average bitrate for overall progress

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -460,9 +460,9 @@
         },
 
         _renderExtendedProgress: function (data) {
-            return this._formatBitrate(data.bitrate) + ' | ' +
+            return this._formatBitrate(data.avgbitrate ? data.avgbitrate : data.bitrate) + ' | ' +
                 this._formatTime(
-                    (data.total - data.loaded) * 8 / data.bitrate
+                    (data.total - data.loaded) * 8 / data.avgbitrate
                 ) + ' | ' +
                 this._formatPercentage(
                     data.loaded / data.total

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -291,6 +291,7 @@
 
         _BitrateTimer: function () {
             this.timestamp = ((Date.now) ? Date.now() : (new Date()).getTime());
+            this.timestamp0 = this.timestamp;
             this.loaded = 0;
             this.bitrate = 0;
             this.getBitrate = function (now, loaded, interval) {
@@ -301,6 +302,10 @@
                     this.timestamp = now;
                 }
                 return this.bitrate;
+            };
+            this.getAvgBitrate = function (now, loaded) {
+                var timeDiff = now - this.timestamp0;
+                return loaded * (1000 / timeDiff) * 8;
             };
         },
 
@@ -382,6 +387,10 @@
                     now,
                     this._progress.loaded,
                     data.bitrateInterval
+                );
+                this._progress.avgbitrate = this._bitrateTimer.getAvgBitrate(
+                    now,
+                    this._progress.loaded
                 );
                 data._progress.loaded = data.loaded = loaded;
                 data._progress.bitrate = data.bitrate = data._bitrateTimer.getBitrate(
@@ -821,7 +830,7 @@
                 this._bitrateTimer = new this._BitrateTimer();
                 // Reset the global progress values:
                 this._progress.loaded = this._progress.total = 0;
-                this._progress.bitrate = 0;
+                this._progress.bitrate = this._progress.avgbitrate = 0;
             }
             // Make sure the container objects for the .response() and
             // .progress() methods on the data object are available


### PR DESCRIPTION
Especially when uploading large files with big chunks the bitrate
display and the remaining time display become bumpy. This happens
when an onProgress event is fired while a bigger chunk is processed
at the server as the throughput may be very low at this moment.

Signed-off-by: Peter Lieven pl@kamp.de
