### PR TITLE
Added option setContentDisposition

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -159,6 +159,10 @@
             bitrateInterval: 500,
             // By default, uploads are started automatically when adding files:
             autoUpload: true,
+            // By default, set Content-Disposition header on non-multipart
+            // file-uploads, might need to be set to false if this header is not
+            // allowed server-side
+            setContentDisposition: true,
 
             // Error and info messages:
             messages: {
@@ -444,7 +448,10 @@
             if (options.contentRange) {
                 options.headers['Content-Range'] = options.contentRange;
             }
-            if (!multipart || options.blob || !this._isInstanceOf('File', file)) {
+            if (
+                    options.setContentDisposition &&
+                    (!multipart || options.blob || !this._isInstanceOf('File', file))
+                ) {
                 options.headers['Content-Disposition'] = 'attachment; filename="' +
                     encodeURI(file.name) + '"';
             }


### PR DESCRIPTION
> Added option setContentDisposition, can be used to prevent setting a Content-Disposition header which might be disallowed on some server-side handlers.

So a few months ago, I ran into some issues trying to implement PUT uploads on Vimeo using jQuery File Upload. It looks like the `Content-Disposition` header, which is set on non-multipart uploads, is actually disallowed by Vimeo.

> [Error] XMLHttpRequest cannot load https://1511632926.cloud.vimeo.com/upload?[...]. Request header field Content-Disposition is not allowed by Access-Control-Allow-Headers. (90, line 0)

Here is a post on Stack Overflow where I explained how I "fixed" the issue : http://stackoverflow.com/questions/26222413/vimeo-api-streaming-upload-using-http-put-and-blueimps-jquery-fileupload
I thought it would be best to have a clean way to disable this feature, so I added an option `setContentDisposition`, it is set to `true` by default which preserves the original behaviour.
