### PR TITLE
Update README to reflect that issue tracker is disabled on this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Supports cross-domain, chunked and resumable file uploads and client-side image 
 [Support Forum](https://groups.google.com/d/forum/jquery-fileupload).  
 If your question is not directly related to the File Upload plugin, you might have a better chance to get a reply by posting to [Stack Overflow](http://stackoverflow.com/questions/tagged/blueimp+jquery+file-upload).
 
-* Bugs and Feature requests  
-**Bugs** and **Feature requests** can be reported using the [issues tracker](https://github.com/blueimp/jQuery-File-Upload/issues).  
-Please read the [issue guidelines](https://github.com/blueimp/jQuery-File-Upload/blob/master/CONTRIBUTING.md) before posting.
+* Bugs and new features
+**Bug fixes** and **new features** can be proposed using [pull requests](https://github.com/blueimp/jQuery-File-Upload/pulls).
+Please read the [contribution guidelines](https://github.com/blueimp/jQuery-File-Upload/blob/master/CONTRIBUTING.md) before posting.
 
 ## Features
 * **Multiple file upload:**  


### PR DESCRIPTION
This is just a suggestion. I would've instead filed an issue about this part of the README being wrong, but the whole problem is that that's currently impossible :laughing: 
