### PR TITLE
Ensure data object creation is the same for each event.

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1202,10 +1202,7 @@
 
         _onChange: function (e) {
             var that = this,
-                data = {
-                    fileInput: $(e.target),
-                    form: $(e.target.form)
-                };
+                data = this._newData(e);
             this._getFileInputFiles(data.fileInput).always(function (files) {
                 data.files = files;
                 if (that.options.replaceFileInput) {
@@ -1224,7 +1221,7 @@
         _onPaste: function (e) {
             var items = e.originalEvent && e.originalEvent.clipboardData &&
                     e.originalEvent.clipboardData.items,
-                data = {files: []};
+                data = this._newData(e);
             if (items && items.length) {
                 $.each(items, function (index, item) {
                     var file = item.getAsFile && item.getAsFile();
@@ -1246,7 +1243,7 @@
             e.dataTransfer = e.originalEvent && e.originalEvent.dataTransfer;
             var that = this,
                 dataTransfer = e.dataTransfer,
-                data = {};
+                data = this._newData(e);
             if (dataTransfer && dataTransfer.files && dataTransfer.files.length) {
                 e.preventDefault();
                 this._getDroppedFiles(dataTransfer).always(function (files) {
@@ -1260,6 +1257,14 @@
                     }
                 });
             }
+        },
+
+        _newData: function(e) {
+          return {
+            fileInput: $(e.target),
+            form: $(e.target.form),
+            files: []
+          };
         },
 
         _onDragOver: getDragHandler('dragover'),


### PR DESCRIPTION
Hello friends!

I ran into a problem with the data object not having the form attribute.  This was caused by three different event handlers constructing the data object differently.

The bad behavior can be seen here in this fiddle: http://jsfiddle.net/spy8d6n0/2/  Clicking the input button and adding a file will have the correct form attribute, but drag and dropping a file will not.

This pull request ensures that the data object's construction is the same no matter what event triggers a file to be added.
