### PR TITLE
CommonJS/Browserify support fix

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1,5 +1,5 @@
 /*
- * jQuery File Upload Plugin 5.42.1
+ * jQuery File Upload Plugin 5.42.2
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2010, Sebastian Tschan
@@ -20,6 +20,12 @@
             'jquery',
             'jquery.ui.widget'
         ], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS:
+        factory(
+            require('jquery'),
+            require('./vendor/jquery.ui.widget')
+        );
     } else {
         // Browser globals:
         factory(window.jQuery);

--- a/js/vendor/jquery.ui.widget.js
+++ b/js/vendor/jquery.ui.widget.js
@@ -1,4 +1,4 @@
-/*! jQuery UI - v1.11.1 - 2014-09-17
+/*! jQuery UI - v1.11.1+CommonJS - 2014-09-17
 * http://jqueryui.com
 * Includes: widget.js
 * Copyright 2014 jQuery Foundation and other contributors; Licensed MIT */
@@ -8,6 +8,11 @@
 
 		// AMD. Register as an anonymous module.
 		define([ "jquery" ], factory );
+
+	} else if (typeof exports === "object") {
+		// Node/CommonJS:
+		factory(require("jquery"));
+
 	} else {
 
 		// Browser globals


### PR DESCRIPTION
https://github.com/blueimp/jQuery-File-Upload/pull/3370 introduced support for commonjs/browserify.
Unfortunately the entry point file "jquery.fileupload.js" was left untouched so it is still impossible to use this plugin with browserify.
This PR fixes that.

Thank you for your hard work!