### PR TITLE
Fix a bug that prevents to load (and then resize) image

### DIFF
--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -159,7 +159,7 @@
                     file = data.files[data.index],
                     dfd = $.Deferred();
                 if (($.type(options.maxFileSize) === 'number' &&
-                            file.size > options.maxFileSize) ||
+                            file.size < options.maxFileSize) ||
                         (options.fileTypes &&
                             !options.fileTypes.test(file.type)) ||
                         !loadImage(


### PR DESCRIPTION
A comparison between maxFileSize and the actual file size was in the wrong direction