### PR TITLE
Fix issue that get_image_size() return incorrect info when $file_path co...

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -978,7 +978,7 @@ class UploadHandler
                 exec($cmd, $output, $error);
                 if (!$error && !empty($output)) {
                     // image.jpg JPEG 1920x1080 1920x1080+0+0 8-bit sRGB 465KB 0.000u 0:00.000
-                    $infos = preg_split('/\s+/', $output[0]);
+                    $infos = preg_split('/\s+/', substr($output[0], strlen($file_path)));
                     $dimensions = preg_split('/x/', $infos[2]);
                     return $dimensions;
                 }


### PR DESCRIPTION
...ntains whitespace

```sh
[1] boris> preg_split('/\s+/', '/path/to/image (1).jpg JPEG 633x354 633x354+0+0 8-bit sRGB 45.1KB 0.000u 0:00.000');
// array(
//   0 => '/path/to/image',
//   1 => '(1).jpg',
//   2 => 'JPEG',
//   3 => '633x354',
//   4 => '633x354+0+0',
//   5 => '8-bit',
//   6 => 'sRGB',
//   7 => '45.1KB',
//   8 => '0.000u',
//   9 => '0:00.000'
// )
```