### PR TITLE
Add spm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.pyc
 node_modules
+spm_modules

--- a/.spmignore
+++ b/.spmignore
@@ -1,0 +1,4 @@
+cors
+spm_modules
+test
+server

--- a/package.json
+++ b/package.json
@@ -51,5 +51,11 @@
     "grunt": "~0.4.5",
     "grunt-bump-build-git": "~1.1.1",
     "grunt-contrib-jshint": "~0.10.0"
+  },
+  "spm": {
+    "main": "js/jquery.fileupload.js",
+    "dependencies": {
+      "jquery": ">=1.7"
+    }
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/blueimp-file-upload

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of blueimp-file-upload in spmjs, I would like to add it for your account after signing in http://spmjs.io.

spmjs/spm#781