### PR TITLE
small fixes in UploadHandler

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -838,7 +838,7 @@ class UploadHandler
             $this->get_scaled_image_file_paths($file_name, $version);
         $image = $this->imagick_get_image_object(
             $file_path,
-            !empty($options['no_cache'])
+            !empty($options['crop']) || !empty($options['no_cache'])
         );
         if ($image->getImageFormat() === 'GIF') {
             // Handle animated GIFs:
@@ -968,7 +968,7 @@ class UploadHandler
                         return $dimensions;
                     }
                     return false;
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     error_log($e->getMessage());
                 }
             }


### PR DESCRIPTION
    - correct cropping in function imagick_create_scaled_image
      if option no-cache isnt set imagick remebers last thumbnail size and not cropping other sizes correctly
    - add \ to Exception in function get_image_size


or better option will be clone?
```
        $orig_img = $this->imagick_get_image_object(
            $file_path,
            !empty($options['no_cache'])
        );
        $image = clone $orig_img;
```
the same problem has gd