### PR TITLE
useSubmit option

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -165,6 +165,8 @@
             bitrateInterval: 500,
             // By default, uploads are started automatically when adding files:
             autoUpload: true,
+            // if true, submit file when form is submitted.
+            useSubmit: false,
 
             // Error and info messages:
             messages: {
@@ -450,11 +452,11 @@
             if (options.contentRange) {
                 options.headers['Content-Range'] = options.contentRange;
             }
-            if (!multipart || options.blob || !this._isInstanceOf('File', file)) {
+            if (file && (!multipart || options.blob || !this._isInstanceOf('File', file))) {
                 options.headers['Content-Disposition'] = 'attachment; filename="' +
                     encodeURI(file.name) + '"';
             }
-            if (!multipart) {
+            if (file && !multipart) {
                 options.contentType = file.type || 'application/octet-stream';
                 options.data = options.blob || file;
             } else if ($.support.xhrFormDataFileUpload) {
@@ -718,6 +720,7 @@
         // should be uploaded in chunks, but does not invoke any
         // upload requests:
         _chunkedUpload: function (options, testOnly) {
+            if (!options.files || options.files.length == 0) return false;
             options.uploadedBytes = options.uploadedBytes || 0;
             var that = this,
                 file = options.files[0],
@@ -1227,6 +1230,27 @@
             });
         },
 
+        _onSubmit: function (e) {
+            var that = this,
+                data = {
+                    form: $(e.target)
+                };
+            data.fileInput = $('input[type=file]', e.target);
+            if (!data.fileInput.val()) {
+              data.files = [];
+              this._onSend(e, data);
+            }
+            this._getFileInputFiles(data.fileInput).always(function (files) {
+                data.files = files;
+                if (that.options.replaceFileInput) {
+                    that._replaceFileInput(data.fileInput);
+                }
+                that._onAdd(e, data);
+            });
+          e.preventDefault();
+          return false;
+        },
+
         _onPaste: function (e) {
             var items = e.originalEvent && e.originalEvent.clipboardData &&
                     e.originalEvent.clipboardData.items,
@@ -1288,10 +1312,15 @@
                     paste: this._onPaste
                 });
             }
-            if ($.support.fileInput) {
+            if ($.support.fileInput && !this.options.useSubmit) {
                 this._on(this.options.fileInput, {
                     change: this._onChange
                 });
+            }
+            if (this.options.useSubmit) {
+              this._on(this.options.fileInput[0].form, {
+                submit: this._onSubmit
+              });
             }
         },
 


### PR DESCRIPTION
Currently, fileupload only works either a) when the file is selected, or b) manually via API. However, often we want to submit the form via Ajax. There are complications here - for example, we want to allow for optional file entry, where the form is still submitted even if no file is selected. The only current way around that is a complex and non-DRY method where we copy all the Ajax settings we passed into the fileupload plugin and have a separate submit listener that replicates the functionality only if no file has been selected.

This change adds a ``useSubmit`` option. In this case, selecting a file won't fire the send method; instead, it is *always* fired when the form is submitted, regardless of whether a file has been added or not. All existing callbacks should still work exactly as expected, including ``_onAdd``.