### PR TITLE
Fixed regex for replacing existing file extension

### DIFF
--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -242,7 +242,7 @@
                                     blob.name = file.name;
                                 } else if (file.name) {
                                     blob.name = file.name.replace(
-                                        /\..+$/,
+                                        /\.\w+$/,
                                         '.' + blob.type.substr(6)
                                     );
                                 }

--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -247,12 +247,6 @@
                                     );
                                 }
                             }
-                            // Keep track of the original size in case
-                            // we want to see extent of compression
-                            if (!blob.originalSize) {
-								blob.originalSize = file.size;
-                            }
-                            
                             // Don't restore invalid meta data:
                             if (file.type !== blob.type) {
                                 delete data.imageHead;
@@ -297,7 +291,6 @@
                         this._blobSlice.call(file, 20)
                     ], {type: file.type});
                 blob.name = file.name;
-    			blob.originalSize = file.size;
                 data.files[data.index] = blob;
                 return data;
             },

--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -247,6 +247,12 @@
                                     );
                                 }
                             }
+                            // Keep track of the original size in case
+                            // we want to see extent of compression
+                            if (!blob.originalSize) {
+								blob.originalSize = file.size;
+                            }
+                            
                             // Don't restore invalid meta data:
                             if (file.type !== blob.type) {
                                 delete data.imageHead;
@@ -291,6 +297,7 @@
                         this._blobSlice.call(file, 20)
                     ], {type: file.type});
                 blob.name = file.name;
+    			blob.originalSize = file.size;
                 data.files[data.index] = blob;
                 return data;
             },


### PR DESCRIPTION
The existing regex did not account for file names containing multiple periods ("."), so a file named <code>abc.123.[xxx]</code> was being converted to <code>abc.[yyy]</code> (expected file name was <code>abc.123.[yyy]</code> in this case).

Here's a fiddle to illustrate: https://jsfiddle.net/guag/sj9a8Lwx/