### PR TITLE
Fix vertical misalignment in Firefox

### DIFF
--- a/css/jquery.fileupload.css
+++ b/css/jquery.fileupload.css
@@ -21,7 +21,6 @@
   margin: 0;
   opacity: 0;
   -ms-filter: 'alpha(opacity=0)';
-  font-size: 200px;
   direction: ltr;
   cursor: pointer;
 }


### PR DESCRIPTION
Text on the upload button is unreadable in Firefox because it is misaligned vertically. Removing the explicit font-size fixes the issue.