### PR TITLE
XHR timeout disabled is required for file uploads.

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -277,7 +277,8 @@
             // The following are jQuery ajax settings required for the file uploads:
             processData: false,
             contentType: false,
-            cache: false
+            cache: false,
+            timeout: 0
         },
 
         // A list of options that require reinitializing event listeners and/or


### PR DESCRIPTION
A timeout (e.g. set globally to work around certain Google Chrome bugs) would otherwise break file uploads lasting longer than the set value.