### PR TITLE
Prevent clicks around button without Bootstrap

### DIFF
--- a/css/jquery.fileupload.css
+++ b/css/jquery.fileupload.css
@@ -13,6 +13,7 @@
 .fileinput-button {
   position: relative;
   overflow: hidden;
+  display: inline-block;
 }
 .fileinput-button input {
   position: absolute;


### PR DESCRIPTION
Without Bootstrap, jQuery File Upload allows clicks not only on the upload button, but around it. See the concerned area in the screenshot below:

![screen shot 2015-06-22 at 11 46 24](https://cloud.githubusercontent.com/assets/42327/8279465/28de9caa-18d5-11e5-8238-259f4a736fa6.png)

With Bootstrap, this is not an issue as `.btn` is marked as `display: inline-block`. This fixes the issue for everybody using jQuery File Upload without Bootstrap.