### PR TITLE
Fix path for jquery.ui.widget in AMD module

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -18,7 +18,7 @@
         // Register as an anonymous AMD module:
         define([
             'jquery',
-            'jquery.ui.widget'
+            './vendor/jquery.ui.widget'
         ], factory);
     } else if (typeof exports === 'object') {
         // Node/CommonJS:


### PR DESCRIPTION
If I do `npm install blueimp-file-upload-jquery-ui --save` and try to require your package in Webpack, I get the error:

```
ERROR in ./~/blueimp-file-upload/js/jquery.fileupload.js
Module not found: Error: Cannot resolve module 'jquery.ui.widget' in /Users/alex/Projects/infoeducatie-ui/node_modules/blueimp-file-upload/js
 @ ./~/blueimp-file-upload/js/jquery.fileupload.js 19:8-22:19
```

The pull request fixes my problem, but I don't know if AMD requirejs will work. My current stack is `npm 2.10.1`, `node v0.12.4` and `"webpack": "^1.9.11"`.