### PR TITLE
Exposing license information according to bower format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,12 +40,7 @@
     "url": "git://github.com/blueimp/jQuery-File-Upload.git"
   },
   "bugs": "https://github.com/blueimp/jQuery-File-Upload/issues",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "jquery": ">=1.6",
     "blueimp-tmpl": ">=2.5.4",


### PR DESCRIPTION
`license` field should contain String or Array of Strings. See: http://bower.io/docs/creating-packages/

Current format doesn't work with libraries that inspect and generate information about all the libraries used in the project (e.g. `grunt-license-bower`).