### PR TITLE
Handle max_width and max_height correctly

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -944,7 +944,7 @@ class UploadHandler
             // Handle animated GIFs:
             $cmd .= ' -coalesce';
             if (empty($options['crop'])) {
-                $cmd .= ' -resize '.escapeshellarg($resize.'>');
+                $cmd .= ' -resize '.escapeshellarg($resize.'\>');
             } else {
                 $cmd .= ' -resize '.escapeshellarg($resize.'^');
                 $cmd .= ' -gravity center';


### PR DESCRIPTION
With the medium size set to resize images on upload, replacing `>` with `\>` forces imagemagick to resize both dimensions to fit within the max height and width.