### PR TITLE
Changed FileUpload add method to use asyncApply to avoid UI blocking …

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -91,7 +91,7 @@
                     angular.forEach(data.files, function (file) {
                         filesCopy.push(file);
                     });
-                    scope.$apply(function () {
+                    scope.$parent.$applyAsync(function () {
                         addFileMethods(scope, data);
                         var method = scope.option('prependFiles') ?
                                 'unshift' : 'push';
@@ -100,7 +100,7 @@
                     data.process(function () {
                         return scope.process(data);
                     }).always(function () {
-                        scope.$apply(function () {
+                        scope.$parent.$applyAsync(function () {
                             addFileMethods(scope, data);
                             scope.replace(filesCopy, data.files);
                         });
@@ -320,9 +320,11 @@
                     'fileuploadprocessalways',
                     'fileuploadprocessstop'
                 ].join(' '), function (e, data) {
-                    if ($scope.$emit(e.type, data).defaultPrevented) {
-                        e.preventDefault();
-                    }
+                    $scope.$parent.$applyAsync(function () {
+                        if ($scope.$emit(e.type, data).defaultPrevented) {
+                            e.preventDefault();
+                        }
+                    });
                 }).on('remove', function () {
                     // Remove upload methods from the scope,
                     // when the widget is removed:


### PR DESCRIPTION
…and improve responsiveness when uploading a lot of files.
When uploading a lot of file $apply uses a lot of ressources (the more files - the more it is called).
Therefore using $asyncApply will allow the UI to refresh and improve responsiveness.