### PR TITLE
Fix issue with aborted file uploads causing an 'digest already in pro…

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -116,7 +116,7 @@
                     if (e.isDefaultPrevented()) {
                         return false;
                     }
-                    data.scope.$apply();
+                    data.scope.safeApply();
                 },
                 done: function (e, data) {
                     if (e.isDefaultPrevented()) {
@@ -199,6 +199,18 @@
         .controller('FileUploadController', [
             '$scope', '$element', '$attrs', '$window', 'fileUpload',
             function ($scope, $element, $attrs, $window, fileUpload) {
+
+                $scope.safeApply = function(fn) {
+                    var phase = this.$root.$$phase;
+                    if(phase == '$apply' || phase == '$digest') {
+                        if(fn && (typeof(fn) === 'function')) {
+                            fn();
+                        }
+                    } else {
+                        this.$apply(fn);
+                    }
+                };
+
                 var uploadMethods = {
                     progress: function () {
                         return $element.fileupload('progress');


### PR DESCRIPTION
…gress' error, added a safe $apply method

In our experience it only happend in that case. However it may be necessary in the future to use the safeApply in other places.