### PR TITLE
Restore focus after _replaceFileInput

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1046,13 +1046,19 @@
 
         _replaceFileInput: function (data) {
             var input = data.fileInput,
-                inputClone = input.clone(true);
+                inputClone = input.clone(true),
+                restoreFocus = input.is(document.activeElement);
             // Add a reference for the new cloned file input to the data argument:
             data.fileInputClone = inputClone;
             $('<form></form>').append(inputClone)[0].reset();
             // Detaching allows to insert the fileInput on another form
             // without loosing the file input value:
             input.after(inputClone).detach();
+            // If the fileInput had focus before it was detached,
+            // restore focus to the inputClone.
+            if (restoreFocus) {
+                inputClone.focus();
+            }
             // Avoid memory leaks with the detached file input:
             $.cleanData(input.unbind('remove'));
             // Replace the original file input element in the fileInput


### PR DESCRIPTION
If the fileInput has keyboard focus before it is detached, document focus will be lost. To avoid this change in context, restore focus to the inputClone.