### PR TITLE
Update jquery.fileupload-image.js for browserify

### DIFF
--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -29,7 +29,12 @@
         // Node/CommonJS:
         factory(
             require('jquery'),
-            require('load-image')
+            require('blueimp-load-image/js/load-image'),
+            require('blueimp-load-image/js/load-image-meta'),
+            require('blueimp-load-image/js/load-image-exif'),
+            require('blueimp-load-image/js/load-image-ios'),
+            require('blueimp-canvas-to-blob'),
+            require('./jquery.fileupload-process')
         );
     } else {
         // Browser globals:


### PR DESCRIPTION
to make it work with browserify, module "load-image" does not exist