### PR TITLE
Remove load-image-ios

### DIFF
--- a/js/jquery.fileupload-image.js
+++ b/js/jquery.fileupload-image.js
@@ -21,7 +21,6 @@
             'load-image',
             'load-image-meta',
             'load-image-exif',
-            'load-image-ios',
             'canvas-to-blob',
             './jquery.fileupload-process'
         ], factory);


### PR DESCRIPTION
The latest release of blueimp-load-image does not provide the module load-image-ios anymore