### PR TITLE
Make font size for fileinput-button !important so it's less likely to break

### DIFF
--- a/css/jquery.fileupload.css
+++ b/css/jquery.fileupload.css
@@ -22,7 +22,7 @@
   margin: 0;
   opacity: 0;
   -ms-filter: 'alpha(opacity=0)';
-  font-size: 200px;
+  font-size: 200px !important;
   direction: ltr;
   cursor: pointer;
 }


### PR DESCRIPTION
It did already for me once before I noticed what the issue was, if the invisible file chooser isn't big enough then clicking on the formatted button might not do anything (depending on browser, e.g. happens on IE<10 if I remember correctly).