### PR TITLE
Images is automatic resize before upload in chrome 50

### DIFF
--- a/angularjs.html
+++ b/angularjs.html
@@ -229,5 +229,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-41071247-1', 'blueimp.github.io');
 ga('send', 'pageview');
 </script>
+<script>window.cookieconsent_options={"message":"This website uses cookies to ensure you get the best experience on our website","dismiss":"Got it!","learnMore":"More info","link":null,"theme":"light-bottom"};</script>
+<script async src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
 </body>
 </html>

--- a/angularjs.html
+++ b/angularjs.html
@@ -62,8 +62,22 @@
     </div>
 </div>
 <div class="container">
-    <h1>jQuery File Upload Demo</h1>
-    <h2 class="lead">AngularJS version</h2>
+    <div class="clearfix">
+        <div class="pull-left">
+            <h1>jQuery File Upload Demo</h1>
+            <h2 class="lead">AngularJS version</h2>
+        </div>
+        <p class="pull-right">
+            <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+            <ins class="adsbygoogle"
+                 style="display:inline-block;width:320px;height:100px"
+                 data-ad-client="ca-pub-4004031949998028"
+                 data-ad-slot="8543690390"></ins>
+            <script>
+            (adsbygoogle = window.adsbygoogle || []).push({});
+            </script>
+        </p>
+    </div>
     <ul class="nav nav-tabs">
         <li><a href="basic.html">Basic</a></li>
         <li><a href="basic-plus.html">Basic Plus</a></li>

--- a/angularjs.html
+++ b/angularjs.html
@@ -207,5 +207,13 @@
 <script src="js/jquery.fileupload-angular.js"></script>
 <!-- The main application script -->
 <script src="js/app.js"></script>
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-41071247-1', 'blueimp.github.io');
+ga('send', 'pageview');
+</script>
 </body>
 </html>

--- a/basic-plus.html
+++ b/basic-plus.html
@@ -244,5 +244,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-41071247-1', 'blueimp.github.io');
 ga('send', 'pageview');
 </script>
+<script>window.cookieconsent_options={"message":"This website uses cookies to ensure you get the best experience on our website","dismiss":"Got it!","learnMore":"More info","link":null,"theme":"light-bottom"};</script>
+<script async src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
 </body>
 </html>

--- a/basic-plus.html
+++ b/basic-plus.html
@@ -48,8 +48,22 @@
     </div>
 </div>
 <div class="container">
-    <h1>jQuery File Upload Demo</h1>
-    <h2 class="lead">Basic Plus version</h2>
+    <div class="clearfix">
+        <div class="pull-left">
+            <h1>jQuery File Upload Demo</h1>
+            <h2 class="lead">Basic Plus version</h2>
+        </div>
+        <p class="pull-right">
+            <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+            <ins class="adsbygoogle"
+                 style="display:inline-block;width:320px;height:100px"
+                 data-ad-client="ca-pub-4004031949998028"
+                 data-ad-slot="8543690390"></ins>
+            <script>
+            (adsbygoogle = window.adsbygoogle || []).push({});
+            </script>
+        </p>
+    </div>
     <ul class="nav nav-tabs">
         <li><a href="basic.html">Basic</a></li>
         <li class="active"><a href="basic-plus.html">Basic Plus</a></li>

--- a/basic-plus.html
+++ b/basic-plus.html
@@ -222,5 +222,13 @@ $(function () {
         .parent().addClass($.support.fileInput ? undefined : 'disabled');
 });
 </script>
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-41071247-1', 'blueimp.github.io');
+ga('send', 'pageview');
+</script>
 </body>
 </html>

--- a/basic.html
+++ b/basic.html
@@ -132,5 +132,13 @@ $(function () {
         .parent().addClass($.support.fileInput ? undefined : 'disabled');
 });
 </script>
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-41071247-1', 'blueimp.github.io');
+ga('send', 'pageview');
+</script>
 </body>
 </html>

--- a/basic.html
+++ b/basic.html
@@ -48,8 +48,22 @@
     </div>
 </div>
 <div class="container">
-    <h1>jQuery File Upload Demo</h1>
-    <h2 class="lead">Basic version</h2>
+    <div class="clearfix">
+        <div class="pull-left">
+            <h1>jQuery File Upload Demo</h1>
+            <h2 class="lead">Basic version</h2>
+        </div>
+        <p class="pull-right">
+            <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+            <ins class="adsbygoogle"
+                 style="display:inline-block;width:320px;height:100px"
+                 data-ad-client="ca-pub-4004031949998028"
+                 data-ad-slot="8543690390"></ins>
+            <script>
+            (adsbygoogle = window.adsbygoogle || []).push({});
+            </script>
+        </p>
+    </div>
     <ul class="nav nav-tabs">
         <li class="active"><a href="basic.html">Basic</a></li>
         <li><a href="basic-plus.html">Basic Plus</a></li>

--- a/basic.html
+++ b/basic.html
@@ -154,5 +154,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-41071247-1', 'blueimp.github.io');
 ga('send', 'pageview');
 </script>
+<script>window.cookieconsent_options={"message":"This website uses cookies to ensure you get the best experience on our website","dismiss":"Got it!","learnMore":"More info","link":null,"theme":"light-bottom"};</script>
+<script async src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -56,8 +56,22 @@
     </div>
 </div>
 <div class="container">
-    <h1>jQuery File Upload Demo</h1>
-    <h2 class="lead">Basic Plus UI version</h2>
+    <div class="clearfix">
+        <div class="pull-left">
+            <h1>jQuery File Upload Demo</h1>
+            <h2 class="lead">Basic Plus UI version</h2>
+        </div>
+        <p class="pull-right">
+            <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+            <ins class="adsbygoogle"
+                 style="display:inline-block;width:320px;height:100px"
+                 data-ad-client="ca-pub-4004031949998028"
+                 data-ad-slot="8543690390"></ins>
+            <script>
+            (adsbygoogle = window.adsbygoogle || []).push({});
+            </script>
+        </p>
+    </div>
     <ul class="nav nav-tabs">
         <li><a href="basic.html">Basic</a></li>
         <li><a href="basic-plus.html">Basic Plus</a></li>

--- a/index.html
+++ b/index.html
@@ -251,5 +251,13 @@
 <!--[if (gte IE 8)&(lt IE 10)]>
 <script src="js/cors/jquery.xdr-transport.js"></script>
 <![endif]-->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-41071247-1', 'blueimp.github.io');
+ga('send', 'pageview');
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -273,5 +273,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-41071247-1', 'blueimp.github.io');
 ga('send', 'pageview');
 </script>
+<script>window.cookieconsent_options={"message":"This website uses cookies to ensure you get the best experience on our website","dismiss":"Got it!","learnMore":"More info","link":null,"theme":"light-bottom"};</script>
+<script async src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
 </body>
 </html>

--- a/jquery-ui.html
+++ b/jquery-ui.html
@@ -52,6 +52,16 @@
     <li><a href="https://blueimp.net">&copy; blueimp.net</a></li>
 </ul>
 <h1>jQuery File Upload Demo</h1>
+<p style="float:right">
+    <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+    <ins class="adsbygoogle"
+         style="display:inline-block;width:320px;height:100px"
+         data-ad-client="ca-pub-4004031949998028"
+         data-ad-slot="8543690390"></ins>
+    <script>
+    (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+</p>
 <h2>jQuery UI version</h2>
 <form>
     <label for="theme-switcher">Theme:</label>

--- a/jquery-ui.html
+++ b/jquery-ui.html
@@ -264,5 +264,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-41071247-1', 'blueimp.github.io');
 ga('send', 'pageview');
 </script>
+<script>window.cookieconsent_options={"message":"This website uses cookies to ensure you get the best experience on our website","dismiss":"Got it!","learnMore":"More info","link":null,"theme":"light-bottom"};</script>
+<script async src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
 </body>
 </html>

--- a/jquery-ui.html
+++ b/jquery-ui.html
@@ -246,5 +246,13 @@ $('#theme-switcher').change(function () {
 <!--[if (gte IE 8)&(lt IE 10)]>
 <script src="js/cors/jquery.xdr-transport.js"></script>
 <![endif]-->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-41071247-1', 'blueimp.github.io');
+ga('send', 'pageview');
+</script>
 </body>
 </html>


### PR DESCRIPTION
Hi!

I think that this is a bug:
EX:
In Chrome 50, when you select a file with 3MB , the jQuery-File-Upload change the image to 256KB:
you can see this in the Demo:
https://blueimp.github.io/jQuery-File-Upload/

The file is change before upload and the size is always 1080px height.

In Chrome 40-49 the image has the same size that original in the HardDrive. 

RenderPCI