### PR TITLE
fix node.js imports

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -24,6 +24,17 @@
             './jquery.fileupload-video',
             './jquery.fileupload-validate'
         ], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS:
+        factory(
+            require('jquery'),
+            require('angular'),
+            require('./jquery.fileupload'),
+            require('./jquery.fileupload-image'),
+            require('./jquery.fileupload-audio'),
+            require('./jquery.fileupload-video'),
+            require('./jquery.fileupload-validate')
+        );
     } else {
         factory();
     }

--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -29,7 +29,6 @@
         factory(
             require('jquery'),
             require('angular'),
-            require('./jquery.fileupload'),
             require('./jquery.fileupload-image'),
             require('./jquery.fileupload-audio'),
             require('./jquery.fileupload-video'),

--- a/js/jquery.fileupload-audio.js
+++ b/js/jquery.fileupload-audio.js
@@ -25,7 +25,8 @@
         // Node/CommonJS:
         factory(
             require('jquery'),
-            require('load-image')
+            require('blueimp-load-image/js/load-image'),
+            require('./jquery.fileupload-process')
         );
     } else {
         // Browser globals:

--- a/js/jquery.fileupload-process.js
+++ b/js/jquery.fileupload-process.js
@@ -22,7 +22,10 @@
         ], factory);
     } else if (typeof exports === 'object') {
         // Node/CommonJS:
-        factory(require('jquery'));
+        factory(
+            require('jquery'),
+            require('./jquery.fileupload')
+        );
     } else {
         // Browser globals:
         factory(

--- a/js/jquery.fileupload-validate.js
+++ b/js/jquery.fileupload-validate.js
@@ -21,7 +21,10 @@
         ], factory);
     } else if (typeof exports === 'object') {
         // Node/CommonJS:
-        factory(require('jquery'));
+        factory(
+            require('jquery'),
+            require('./jquery.fileupload-process')
+        );
     } else {
         // Browser globals:
         factory(

--- a/js/jquery.fileupload-video.js
+++ b/js/jquery.fileupload-video.js
@@ -25,7 +25,8 @@
         // Node/CommonJS:
         factory(
             require('jquery'),
-            require('load-image')
+            require('blueimp-load-image/js/load-image'),
+            require('blueimp-load-image/js/load-image-meta')
         );
     } else {
         // Browser globals:

--- a/js/jquery.fileupload-video.js
+++ b/js/jquery.fileupload-video.js
@@ -26,7 +26,7 @@
         factory(
             require('jquery'),
             require('blueimp-load-image/js/load-image'),
-            require('blueimp-load-image/js/load-image-meta')
+            require('./jquery.fileupload-process')
         );
     } else {
         // Browser globals:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueimp-file-upload",
-  "version": "9.12.4",
+  "version": "9.12.5",
   "title": "jQuery File Upload",
   "description": "File Upload widget with multiple file selection, drag&amp;drop support, progress bar, validation and preview images, audio and video for jQuery. Supports cross-domain, chunked and resumable file uploads. Works with any server-side platform (Google App Engine, PHP, Python, Ruby on Rails, Java, etc.) that supports standard HTML form file uploads.",
   "keywords": [


### PR DESCRIPTION
This makes some of the node.js style imports more like the AMD ones. This makes it easier to use with webpack. It's still not totally seamless since I still need this special configuration:

```js
{ test: /blueimp-file-upload.*\.js$/, loader: "imports?define=>false" },
```
but otherwise just these lines are now enough:

```js
require('blueimp-file-upload/css/jquery.fileupload.css');
require('blueimp-file-upload/css/jquery.fileupload-ui.css');

require('blueimp-file-upload/js/jquery.iframe-transport.js');
require('blueimp-file-upload/js/jquery.fileupload-angular.js');
```

It would make my life easier to get this applied upstream. Also, if you would be open to avoiding that imports hack, we could probably do it by separating the AMD and node.js package formats the same way jQuery does.