### PR TITLE
report reason for lack of preview

### DIFF
--- a/angularjs.html
+++ b/angularjs.html
@@ -118,6 +118,7 @@
                         <a data-ng-href="{{file.url}}" title="{{file.name}}" download="{{file.name}}" data-gallery><img data-ng-src="{{file.thumbnailUrl}}" alt=""></a>
                     </div>
                     <div class="preview" data-ng-switch-default data-file-upload-preview="file"></div>
+                    <div class="preview" ng-show="file.preview_error">Sorry, {{file.preview_error}}.</div>
                 </td>
                 <td>
                     <p class="name" data-ng-switch data-on="!!file.url">

--- a/js/jquery.fileupload-video.js
+++ b/js/jquery.fileupload-video.js
@@ -79,12 +79,13 @@
                 var file = data.files[data.index],
                     url,
                     video;
-                if (this._videoElement.canPlayType &&
-                        this._videoElement.canPlayType(file.type) &&
-                        ($.type(options.maxFileSize) !== 'number' ||
-                            file.size <= options.maxFileSize) &&
-                        (!options.fileTypes ||
-                            options.fileTypes.test(file.type))) {
+                if (options.fileTypes && !options.fileTypes.test(file.type)) {
+                    // ignore these files
+                } else if (this._videoElement.canPlayType && !this._videoElement.canPlayType(file.type)) {
+                    data.preview_error = 'this file format cannot be previewed';
+                } else if ($.type(options.maxFileSize) === 'number' && file.size > options.maxFileSize) {
+                    data.preview_error = 'this file is too large to preview';
+                } else {
                     url = loadImage.createObjectURL(file);
                     if (url) {
                         video = this._videoElement.cloneNode(false);
@@ -97,8 +98,11 @@
                 return data;
             },
 
-            // Sets the video element as a property of the file object:
+            // Copy the properties set on the data object to the file object
             setVideo: function (data, options) {
+                if (data.preview_error && !options.disabled) {
+                    data.files[data.index]['preview_error'] = data.preview_error;
+                }
                 if (data.video && !options.disabled) {
                     data.files[data.index][options.name || 'preview'] = data.video;
                 }


### PR DESCRIPTION
This provides to the user the reason why a preview cannot be displayed. Just a bit more friendly. I created it as a separate property for backwards compatibility but I think it could also just use the share the property `file.preview`.