### PR TITLE
IE problems with host

### DIFF
--- a/js/cors/jquery.postmessage-transport.js
+++ b/js/cors/jquery.postmessage-transport.js
@@ -84,7 +84,7 @@
                             e = e.originalEvent;
                             var data = e.data,
                                 ev;
-                            if (e.origin === target && data.id === message.id) {
+                            if (target.indexOf(e.origin) > -1 && data.id === message.id) {
                                 if (data.type === 'progress') {
                                     ev = document.createEvent('Event');
                                     ev.initEvent(data.type, false, true);


### PR DESCRIPTION
We see that in IE when you build the target string, the host is with the port, :80, in our case:

loc = $('').prop('href', options.postMessage)[0],
target = loc.protocol + '//' + loc.host

And when you check if target is equal to e.origin, this condition is never true and postmessage never returns to other side.