### PR TITLE
add xsrf-token to headers if there is xsrf-token cookie

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -842,6 +842,15 @@
             // Initialize the global progress values:
             this._progress.loaded += data.loaded;
             this._progress.total += data.total;
+
+            // setup XSRF-TOKEN header if there is a cookie
+            var name = "XSRF-TOKEN=";
+            $.each(document.cookie.split('; '), function(i, value) {
+                if(value.indexOf(name) == 0) {
+                    $.ajaxSetup({ headers: { 'X-XSRF-TOKEN': value.substring(name.length) } });
+                    return false;
+                }
+            });
         },
 
         _onDone: function (result, textStatus, jqXHR, options) {


### PR DESCRIPTION
many app framework have this xsrf token protected for post/put/patch/delete action, like Laravel,

Now angularjs will automatically set the X-XSRF-TOKEN based on XSRF-TOKEN cookie value, so I created this patch that jQuery-File-Upload can also have this header set on each request, 

It's a extremely simple solution, I home you can have this in official codes.

Thanks