### PR TITLE
Change tmpl to blueimp-tmpl for Browserify

### DIFF
--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -18,7 +18,7 @@
         // Register as an anonymous AMD module:
         define([
             'jquery',
-            'tmpl',
+            'blueimp-tmpl',
             './jquery.fileupload-image',
             './jquery.fileupload-audio',
             './jquery.fileupload-video',
@@ -28,7 +28,7 @@
         // Node/CommonJS:
         factory(
             require('jquery'),
-            require('tmpl')
+            require('blueimp-tmpl')
         );
     } else {
         // Browser globals:


### PR DESCRIPTION
Hi,

in fileupload-ui.js is a require('tmpl'), but this must be 'blueimp-tmpl' , else it won't work for browserify since the package name tmpl doesn't exists.