### PR TITLE
use AMD module naming as suggested by jquery site

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -18,7 +18,7 @@
         // Register as an anonymous AMD module:
         define([
             'jquery',
-            'jquery.ui.widget'
+            'jquery-ui/widget'
         ], factory);
     } else if (typeof exports === 'object') {
         // Node/CommonJS:


### PR DESCRIPTION
I ran into an issue importing the jQuery UI Widget module while using the requirejs optimizer. Currently the module is required as 'jqery.ui.widget', this caused the requirejs optimizer to fail. Even with the name mapped to the path for my jquery-ui library it still failed due to relative includes inside the widget module then not being found.

The jQuery UI site (https://learn.jquery.com/jquery-ui/environments/amd/) uses jquery-ui/<modulename> for their imports - changing to this made the problem go away. 
