### PR TITLE
Correctly unset event handlers when destroying the file uploader.

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1311,6 +1311,10 @@
             this._off(this.options.fileInput, 'change');
         },
 
+        _destroy: function () {
+            this._destroyEventHandlers();
+        },
+
         _setOption: function (key, value) {
             var reinit = $.inArray(key, this._specialOptions) !== -1;
             if (reinit) {


### PR DESCRIPTION
Currently, file uploader leaves the event handlers active when "destroy" option is called. This leads to various errors in scenarios when file uploader object is created/destroyed on the fly. This commit fixes this bug by hooking the "destroy" option with the jQuery UI widget dismantling process.