### PR TITLE
Set font size for buttons to a reasonable size

### DIFF
--- a/css/jquery.fileupload.css
+++ b/css/jquery.fileupload.css
@@ -22,7 +22,7 @@
   margin: 0;
   opacity: 0;
   -ms-filter: 'alpha(opacity=0)';
-  font-size: 200px !important;
+  font-size: 100% !important;
   direction: ltr;
   cursor: pointer;
 }


### PR DESCRIPTION
This only applies to users with javascript disabled as the styling is otherwise overwritten by bootstrap.

200px size was introduced in 76ca40b044b7660f17a77ff82f7fcf14b51878a8 which mentions #2635 but the issue appears to be no longer available so I don't know what the point of the incredibly large size was.

For reference, this is how the demo looks with JS disabled:

![screenshot from 2016-11-19 17-57-47](https://cloud.githubusercontent.com/assets/719105/20457038/7ac6daa2-ae82-11e6-9578-4a1ebcbda760.png)
