### PR TITLE
iframe-transport: $.parseJSON replaced with JSON.parse

### DIFF
--- a/js/jquery.iframe-transport.js
+++ b/js/jquery.iframe-transport.js
@@ -197,7 +197,7 @@
                 return iframe && $(iframe[0].body).text();
             },
             'iframe json': function (iframe) {
-                return iframe && $.parseJSON($(iframe[0].body).text());
+                return iframe && JSON.parse($(iframe[0].body).text());
             },
             'iframe html': function (iframe) {
                 return iframe && $(iframe[0].body).html();


### PR DESCRIPTION
as `$.parseJSON`  is deprecated in jQuery 3.x