### PR TITLE
blueimp-load-image>2.11.0 breaks image scaling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "jquery": ">=1.6",
     "blueimp-tmpl": ">=2.5.4",
-    "blueimp-load-image": ">=1.13.0",
+    "blueimp-load-image": ">=1.13.0,<=2.11.0",
     "blueimp-canvas-to-blob": ">=2.1.1"
   },
   "main": [

--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "jquery": ">=1.6",
     "blueimp-tmpl": ">=2.5.4",
-    "blueimp-load-image": ">=1.13.0,<=2.11.0",
+    "blueimp-load-image": ">=1.13.0 <=2.11.0",
     "blueimp-canvas-to-blob": ">=2.1.1"
   },
   "main": [


### PR DESCRIPTION
The moving of scaling into a separate module in blueimp-load-image (https://github.com/blueimp/JavaScript-Load-Image/commit/cad8a5af578969681d9ce5261db53650204cce86) seems to break scaled uploads:

> TypeError: t.scale is not a function. (In 't.scale(a,i)', 't.scale' is undefined)

This pegs that dependency at a lower version so things continue to work until it's fixed.

(you don't seem to have a bug tracker? So not sure where to report the issue for JavaScript-Load-Image)