### PR TITLE
finfo mimetype upload checking

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -381,8 +381,7 @@ class UploadHandler
           // check file contents for mime/type and not extension
           if ( extension_loaded( 'fileinfo' ) ) {
             $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            if ( !empty( $this->options['accept_file_types'] ) )
-            {
+            if ( !empty( $this->options['accept_file_types'] ) ) {
               if ( !in_array( finfo_file($finfo, $uploaded_file ), $this->options['accept_file_types'] ) ) {
                   $file->error = $this->get_error_message('accept_file_types');
                   return false;
@@ -390,9 +389,9 @@ class UploadHandler
             } //empty array means all types allowed
           }else{
              $file->error = $this->get_error_message('finfo_disabled');
+             return false;
           }
-        }elseif ( is_string( $this->options['accept_file_types'] ) )
-        {
+        }elseif ( is_string( $this->options['accept_file_types'] ) ) {
           if (!preg_match($this->options['accept_file_types'], $file->name)) {
             $file->error = $this->get_error_message('accept_file_types');
             return false;


### PR DESCRIPTION
Uses finfo to check actual contents of uploaded file for mime type and
not just the file extention.  If malicious user renames .exe to .jpg this method will detect that.

If user doesn't have finfo, wants to use regex or has an older version of script - it will fall back to original method gracefully.