### PR TITLE
validating both filename and filetype

### DIFF
--- a/js/jquery.fileupload-validate.js
+++ b/js/jquery.fileupload-validate.js
@@ -57,7 +57,7 @@
         options: {
             /*
             // The regular expression for allowed file types, matches
-            // against either file type or file name:
+            // against either file type and file name:
             acceptFileTypes: /(\.|\/)(gif|jpe?g|png)$/i,
             // The maximum allowed file size in bytes:
             maxFileSize: 10000000, // 10 MB
@@ -98,7 +98,7 @@
                             options.maxNumberOfFiles) {
                     file.error = settings.i18n('maxNumberOfFiles');
                 } else if (options.acceptFileTypes &&
-                        !(options.acceptFileTypes.test(file.type) ||
+                        !(options.acceptFileTypes.test(file.type) &&
                         options.acceptFileTypes.test(file.name))) {
                     file.error = settings.i18n('acceptFileTypes');
                 } else if (fileSize > options.maxFileSize) {


### PR DESCRIPTION
Most of the users have use case where they want to test both file type and as well validate that file name should not contain any special characters. Therefore modified validate.js such that it checks both file type and file name.