### PR TITLE
Microsoft Edge: Access is denied error

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -274,7 +274,7 @@
             // chunkalways: function (e, data) {}, // .bind('fileuploadchunkalways', func);
 
             // Callback for failed drop operations:
-			// dropfail: function (e, data) {}, // .bind('fileuploaddropfail', func);
+            // dropfail: function (e, data) {}, // .bind('fileuploaddropfail', func);
 
             // The plugin options are used as settings object for the ajax calls.
             // The following are jQuery ajax settings required for the file uploads:
@@ -1283,15 +1283,15 @@
         },
 
         _verifyCanAccessFiles: function (e) {
-			try {
-				return e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length;
-			}
-			catch (error) {
-				this._trigger('dropfail', e, { errorThrown: error });
-			}
+            try {
+                return e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length;
+            }
+            catch (error) {
+                this._trigger('dropfail', e, { errorThrown: error });
+            }
 
-			return false;
-		},
+            return false;
+        },
 
         _onDragOver: getDragHandler('dragover'),
 

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -273,6 +273,9 @@
             // Callback for completed (success, abort or error) chunk upload requests:
             // chunkalways: function (e, data) {}, // .bind('fileuploadchunkalways', func);
 
+            // Callback for failed drop operations:
+			// dropfail: function (e, data) {}, // .bind('fileuploaddropfail', func);
+
             // The plugin options are used as settings object for the ajax calls.
             // The following are jQuery ajax settings required for the file uploads:
             processData: false,
@@ -1261,10 +1264,10 @@
 
         _onDrop: function (e) {
             e.dataTransfer = e.originalEvent && e.originalEvent.dataTransfer;
+            if (this._verifyCanAccessFiles(e)) {
             var that = this,
                 dataTransfer = e.dataTransfer,
                 data = {};
-            if (dataTransfer && dataTransfer.files && dataTransfer.files.length) {
                 e.preventDefault();
                 this._getDroppedFiles(dataTransfer).always(function (files) {
                     data.files = files;
@@ -1278,6 +1281,17 @@
                 });
             }
         },
+
+        _verifyCanAccessFiles: function (e) {
+			try {
+				return e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length;
+			}
+			catch (error) {
+				this._trigger('dropfail', e, { errorThrown: error });
+			}
+
+			return false;
+		},
 
         _onDragOver: getDragHandler('dragover'),
 

--- a/test/test.js
+++ b/test/test.js
@@ -558,6 +558,25 @@ $(function () {
         });
     });
 
+    test('dropfail', function () {
+        var fu = $('#fileupload').fileupload(),
+            fuo = fu.data('blueimp-fileupload') || fu.data('fileupload');
+        expect(1);
+        fu.fileupload({
+            dropfail: function () {
+                ok(true, 'Triggers dropfail callback');
+            },
+            add: $.noop
+        });
+        var originalEvent = {dataTransfer: {}};
+        Object.defineProperty(originalEvent.dataTransfer, 'files', { get: function () { throw new Error('Access is denied.'); } });
+        fuo._onDrop({
+            data: {fileupload: fuo},
+            originalEvent: originalEvent,
+            preventDefault: $.noop
+        });
+    });
+
     test('dragover', function () {
         var fu = $('#fileupload').fileupload(),
             fuo = fu.data('blueimp-fileupload') || fu.data('fileupload');


### PR DESCRIPTION
If you try to drag drop a file w/ restricted file permissions in Edge, accessing dataTransfer.files (or items) will throw an error.

This catches this error and triggers a 'dropfail' to enable people to attach some handler to recover from this however they please.