### PR TITLE
Allow maxChunkSize to be a function for dynamic chunk size support

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -730,7 +730,7 @@
                 promise = dfd.promise(),
                 jqXHR,
                 upload;
-            if (!(this._isXHRUpload(options) && slice && (ub || mcs < fs)) ||
+            if (!(this._isXHRUpload(options) && slice && (ub || ($.type(mcs) === 'function' ? mcs(options) : mcs) < fs)) ||
                     options.data) {
                 return false;
             }
@@ -753,7 +753,7 @@
                 o.blob = slice.call(
                     file,
                     ub,
-                    ub + mcs,
+                    ub + ($.type(mcs) === 'function' ? mcs(o) : mcs),
                     file.type
                 );
                 // Store the current chunk size, as the blob itself


### PR DESCRIPTION
This change allows `maxChunkSize` to be a function that returns a dynamic result instead of using a fixed value.

This can be useful for allowing an application to use the last known bit rate to decide what the next chunk size should be in order to cap the client-side upload speed over time.