### PR TITLE
Update UploadHandler.php (fixed)

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -138,11 +138,11 @@ class UploadHandler
                     // Automatically rotate images based on EXIF meta data:
                     'auto_orient' => true
                 ),
-                // You can add an array. The key is the name of the version, the array contains the options to apply.
+                // You can add an array. The key is the name of the version (example: 'medium'), the array contains the options to apply.
                 /*
-                'example-of-another-version' => array(
-                    'max_width' => 80,
-                    'max_height' => 80
+                'medium' => array(
+                    'max_width' => 200,
+                    'max_height' => 160
                 ), 
 		*/
                 'thumbnail' => array(

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -138,7 +138,8 @@ class UploadHandler
                     // Automatically rotate images based on EXIF meta data:
                     'auto_orient' => true
                 ),
-                // You can add an array. The key is the name of the version (example: 'medium'), the array contains the options to apply.
+                // You can add an array. The key is the name of the version (example: 'medium'). 
+                // the array contains the options to apply.
                 /*
                 'medium' => array(
                     'max_width' => 200,

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -131,8 +131,8 @@ class UploadHandler
             // Command or path for to the ImageMagick identify binary:
             'identify_bin' => 'identify',
             'image_versions' => array(
-                // The empty image version key defines options for the original image:
-                // Keep in mind: these image manipulations are inherited by all other image versions! 
+                // The empty image version key defines options for the original image.
+                // Keep in mind: these image manipulations are inherited by all other image versions from this point onwards. 
                 // Also note that the property 'no_cache' is not inherited, since it's not a manipulation.
                 '' => array(
                     // Automatically rotate images based on EXIF meta data:

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -142,8 +142,8 @@ class UploadHandler
                 // the array contains the options to apply.
                 /*
                 'medium' => array(
-                    'max_width' => 200,
-                    'max_height' => 160
+                    'max_width' => 800,
+                    'max_height' => 600
                 ), 
 		*/
                 'thumbnail' => array(

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -870,17 +870,17 @@ class UploadHandler
         if (!empty($options['auto_orient'])) {
             $image_oriented = $this->imagick_orient_image($image);
         }
-		$image_resize = false; 
+	$image_resize = false; 
         $new_width = $max_width = $img_width = $image->getImageWidth();
         $new_height = $max_height = $img_height = $image->getImageHeight(); 
 		  
-		// use isset(). User might be setting max_width = 0 (auto in regular resizing). Value 0 would be considered empty when you use empty()
+        // use isset(). User might be setting max_width = 0 (auto in regular resizing). Value 0 would be considered empty when you use empty()
         if (isset($options['max_width'])) {
-			$image_resize = true; 
+            $image_resize = true; 
             $new_width = $max_width = $options['max_width']; 
         }
         if (isset($options['max_height'])) {
-			$image_resize = true;
+            $image_resize = true;
             $new_height = $max_height = $options['max_height'];
         }
         

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -143,7 +143,8 @@ class UploadHandler
                 'example-of-another-version' => array(
                     'max_width' => 80,
                     'max_height' => 80
-                ), */
+                ), 
+		*/
                 'thumbnail' => array(
                     // Uncomment the following to use a defined directory for the thumbnails
                     // instead of a subdirectory based on the version identifier.
@@ -158,8 +159,6 @@ class UploadHandler
                     // 'crop' => true,
                     // 'jpeg_quality' => 70,
                     // 'no_cache' => true, (there's a caching option, but this remembers thumbnail sizes from a previous action!)
-                    // 'max_width' => 0, (t
-                    // 'max_height' => 200,
                     // 'strip' => true, (this strips EXIF tags, such as geolocation)
                     'max_width' => 80, // either specify width, or set to 0. Then width is automatically adjusted - keeping aspect ratio to a specified max_height.
                     'max_height' => 80 // either specify height, or set to 0. Then height is automatically adjusted - keeping aspect ratio to a specified max_width.

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -138,13 +138,14 @@ class UploadHandler
                     // Automatically rotate images based on EXIF meta data:
                     'auto_orient' => true
                 ),
-                // You can add an array. The key is the name of the version (example: 'medium'). 
+                // You can add arrays to generate different versions.
+                // The name of the key is the name of the version (example: 'medium'). 
                 // the array contains the options to apply.
                 /*
                 'medium' => array(
                     'max_width' => 800,
                     'max_height' => 600
-                ), 
+                ),
 		*/
                 'thumbnail' => array(
                     // Uncomment the following to use a defined directory for the thumbnails

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -132,18 +132,18 @@ class UploadHandler
             'identify_bin' => 'identify',
             'image_versions' => array(
                 // The empty image version key defines options for the original image:
-                // Keep in mind that these options are inherited by all other image versions!
+                // Keep in mind: these image manipulations are inherited by all other image versions! 
+                // Also note that the property 'no_cache' is not inherited, since it's not a manipulation.
                 '' => array(
                     // Automatically rotate images based on EXIF meta data:
                     'auto_orient' => true
                 ),
-                // Uncomment the following to create medium sized images:
+                // You can add an array. The key is the name of the version, the array contains the options to apply.
                 /*
-                'medium' => array(
-                    'max_width' => 800,
-                    'max_height' => 600
-                ),
-                */
+                'example-of-another-version' => array(
+                    'max_width' => 80,
+                    'max_height' => 80
+                ), */
                 'thumbnail' => array(
                     // Uncomment the following to use a defined directory for the thumbnails
                     // instead of a subdirectory based on the version identifier.
@@ -154,9 +154,15 @@ class UploadHandler
                     //'upload_url' => $this->get_full_url().'/thumb/',
                     // Uncomment the following to force the max
                     // dimensions and e.g. create square thumbnails:
-                    //'crop' => true,
-                    'max_width' => 80,
-                    'max_height' => 80
+                    // 'auto_orient' => true,
+                    // 'crop' => true,
+                    // 'jpeg_quality' => 70,
+                    // 'no_cache' => true, (there's a caching option, but this remembers thumbnail sizes from a previous action!)
+                    // 'max_width' => 0, (t
+                    // 'max_height' => 200,
+                    // 'strip' => true, (this strips EXIF tags, such as geolocation)
+                    'max_width' => 80, // either specify width, or set to 0. Then width is automatically adjusted - keeping aspect ratio to a specified max_height.
+                    'max_height' => 80 // either specify height, or set to 0. Then height is automatically adjusted - keeping aspect ratio to a specified max_width.
                 )
             ),
             'print_response' => true
@@ -864,25 +870,30 @@ class UploadHandler
         if (!empty($options['auto_orient'])) {
             $image_oriented = $this->imagick_orient_image($image);
         }
+		$image_resize = false; 
         $new_width = $max_width = $img_width = $image->getImageWidth();
-        $new_height = $max_height = $img_height = $image->getImageHeight();
-        if (!empty($options['max_width'])) {
-            $new_width = $max_width = $options['max_width'];
+        $new_height = $max_height = $img_height = $image->getImageHeight(); 
+		  
+		// use isset(). User might be setting max_width = 0 (auto in regular resizing). Value 0 would be considered empty when you use empty()
+        if (isset($options['max_width'])) {
+			$image_resize = true; 
+            $new_width = $max_width = $options['max_width']; 
         }
-        if (!empty($options['max_height'])) {
+        if (isset($options['max_height'])) {
+			$image_resize = true;
             $new_height = $max_height = $options['max_height'];
         }
-        $image_strip = false;
-        if( !empty($options["strip"]) ) {
-            $image_strip = $options["strip"];
-        } 
+        
+        $image_strip = (isset($options['strip']) ? $options['strip'] : false);
+ 
         if ( !$image_oriented && ($max_width >= $img_width) && ($max_height >= $img_height) && !$image_strip && empty($options["jpeg_quality"]) ) {        
             if ($file_path !== $new_file_path) {
                 return copy($file_path, $new_file_path);
             }
             return true;
         }
-        $crop = !empty($options['crop']);
+        $crop = (isset($options['crop']) ? $options['crop'] : false);
+        
         if ($crop) {
             $x = 0;
             $y = 0;

--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -868,8 +868,9 @@ class UploadHandler
         $image_oriented = false;
         if (!empty($options['auto_orient'])) {
             $image_oriented = $this->imagick_orient_image($image);
-        }
-	$image_resize = false; 
+        } 
+	    
+        $image_resize = false; 
         $new_width = $max_width = $img_width = $image->getImageWidth();
         $new_height = $max_height = $img_height = $image->getImageHeight(); 
 		  


### PR DESCRIPTION
Sorry, I'm still new to Github and couldn't change my previous request, so I forked the project and created this commit.



Based on a use case I've encountered:
- sometimes max width/height was ignored and a copy of the 'main' image was returned; rather than a resized version.
- max_width  = 0, max_height = 0 are Imagick resizeImage options. They were ignored in UploadHandler because empty() returns true for '0'. Using isset() now.
- added more comments in the 'thumbnail' version about options.
- added more comments about inheriting of settings (and made it more clear no_cache might be essential and is NOT inherited)

Implemented changes based upon comments.