### PR TITLE
support to modify filename before sending file to server

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -453,7 +453,7 @@
             }
             if (!multipart || options.blob || !this._isInstanceOf('File', file)) {
                 options.headers['Content-Disposition'] = 'attachment; filename="' +
-                    encodeURI(file.name) + '"';
+                    encodeURI(file.Aname) + '"';
             }
             if (!multipart) {
                 options.contentType = file.type || 'application/octet-stream';
@@ -489,7 +489,7 @@
                         });
                     }
                     if (options.blob) {
-                        formData.append(paramName, options.blob, file.name);
+                        formData.append(paramName, options.blob, file.Aname);
                     } else {
                         $.each(options.files, function (index, file) {
                             // This check allows the tests to run with
@@ -500,7 +500,7 @@
                                     ($.type(options.paramName) === 'array' &&
                                         options.paramName[index]) || paramName,
                                     file,
-                                    file.uploadName || file.name
+                                    file.uploadName || file.Aname
                                 );
                             }
                         });


### PR DESCRIPTION
With this change, you can alter the names of the files being added. I need this in order to support IOS file upload, because in that environment all the images selected are called the same: https://stackoverflow.com/questions/21135037/html-upload-on-iphone-ios-filename-is-always-same-image-jpg-image-png

You can change the name the name of the files after applying this mod the following way:

```javascript
add: function (e, data) {
  for(var i=0; i<data.files.length ;i++){
    var randomNumber = Math.floor(Math.random()*1000);
    var seconds = Math.floor(new Date().getTime() / 1000);
    var newName = randomNumber+'_'+seconds+'_'+data.files[i].name;
    data.files[i].Aname = newName;
  }
  ...
}
```