### PR TITLE
allow edge to gc chunks

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -812,6 +812,9 @@
                             o.context,
                             [jqXHR, textStatus, errorThrown]
                         );
+                    }).always(function(){
+                        // Remove progress listener to ease gc of chunks
+                        $(o.xhr().upload).unbind('progress');
                     });
             };
             this._enhancePromise(promise);


### PR DESCRIPTION
Try uploading > 5GB with edge. It does not matter if chunks are used or not. Edge will kill the tab process once it hits 5GB. This can be monitored quite nicely when keeping the EDGE dev tools memory tab open. When the process is killed the tools get closed. Sadly, memory is not even freed after an upload completes.

This PR allows edge to cleanup chunks. Currently, by only omitting the actual upload data from the options used to initialize the progress. Maybe it makes more sense to always omit it ... my js is not good enough to wrap my head around that.

Comments welcome.