### PR TITLE
Bring back support for Node/CommonJS

### DIFF
--- a/js/vendor/jquery.ui.widget.js
+++ b/js/vendor/jquery.ui.widget.js
@@ -1,4 +1,4 @@
-/*! jQuery UI - v1.12.1 - 2018-02-10
+/*! jQuery UI - v1.12.1+CommonJS - 2018-02-10
  * http://jqueryui.com
  * Includes: widget.js
  * Copyright jQuery Foundation and other contributors; Licensed MIT */
@@ -8,6 +8,10 @@
 
     // AMD. Register as an anonymous module.
     define([ "jquery" ], factory );
+  } else if ( typeof exports === "object" ) {
+
+    // Node/CommonJS
+    factory( require( "jquery" ) );
   } else {
 
     // Browser globals


### PR DESCRIPTION
Browserify, which follows CommonJS module conventions, parses the AST for `require` calls to determine the dependencies of a project.

jQuery File Upload used to support this; it was removed in e2cda462610c776a1f7856692c98b1baab02231a when a new version of jquery.ui.widget.js was vendored.