### PR TITLE
Add chunkbeforesend event handler

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -315,6 +315,7 @@
                     'fileuploadpaste',
                     'fileuploaddrop',
                     'fileuploaddragover',
+                    'fileuploadbeforechunksend',
                     'fileuploadchunksend',
                     'fileuploadchunkdone',
                     'fileuploadchunkfail',

--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -315,7 +315,7 @@
                     'fileuploadpaste',
                     'fileuploaddrop',
                     'fileuploaddragover',
-                    'fileuploadbeforechunksend',
+                    'fileuploadchunkbeforesend',
                     'fileuploadchunksend',
                     'fileuploadchunkdone',
                     'fileuploadchunkfail',

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -766,6 +766,8 @@
                 // Expose the chunk bytes position range:
                 o.contentRange = 'bytes ' + ub + '-' +
                     (ub + o.chunkSize - 1) + '/' + fs;
+                // Trigger beforechunksend to allow form data to be updated for this chunk
+                that._trigger('beforechunksend', null, o);
                 // Process the upload data (the blob and potential form data):
                 that._initXHRData(o);
                 // Add progress listeners for this chunk upload:

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -766,8 +766,8 @@
                 // Expose the chunk bytes position range:
                 o.contentRange = 'bytes ' + ub + '-' +
                     (ub + o.chunkSize - 1) + '/' + fs;
-                // Trigger beforechunksend to allow form data to be updated for this chunk
-                that._trigger('beforechunksend', null, o);
+                // Trigger chunkbeforesend to allow form data to be updated for this chunk
+                that._trigger('chunkbeforesend', null, o);
                 // Process the upload data (the blob and potential form data):
                 that._initXHRData(o);
                 // Add progress listeners for this chunk upload:


### PR DESCRIPTION
A use case for using chunked upload requires an MD5 hash to be calculated for each chunk prior to sending, then added to the form data. This allows the server to compare the client calculated MD5 hash against the actual data received, to provide an extra level of integrity checking, catching issues is large files before the end of the full upload. Other usages are conceivable.

The current chunksend handler is triggered after the form data has been initialised for the chunk request, therefore preventing updates to a chunk request to be made.

This PR proposes a chunkbeforesend handler, running just before the form data is initialised, allowing parameters to be added to the request. Let me know if this is acceptable or if you need changes.

With this change the following example can now be used:

```
$('#fileupload').fileupload().on('fileuploadchunkbeforesend', function (e, data) {
      data.formData.chunk_hash = chunk_hashes.shift();
})
```

In addition to the one line change to `js/jquery.fileupload.js` I also added the entry `fileuploadchunkbeforesend` in the Angular code. I'm assuming this is correct.

In the documentation I'd suggest updating https://github.com/blueimp/jQuery-File-Upload/wiki/Chunked-file-uploads#callbacks to 

```
$('#fileupload').fileupload({maxChunkSize: 100000})
    .on('fileuploadchunkbeforesend', function (e, data) {})
    .on('fileuploadchunksend', function (e, data) {})
    .on('fileuploadchunkdone', function (e, data) {})
    .on('fileuploadchunkfail', function (e, data) {})
    .on('fileuploadchunkalways', function (e, data) {});
```

Also to https://github.com/blueimp/jQuery-File-Upload/wiki/Options#callback-options add the line

```
   .bind('fileuploadchunkbeforesend', function (e, data) {/* ... */})
```
and before https://github.com/blueimp/jQuery-File-Upload/wiki/Options#chunksend add

> chunkbeforesend
> ---
> 
> Callback before the start of each chunk upload request, allowing final changes to be made to the request (such as form data updates) prior to sending.

