### PR TITLE
File upload doesn't seem to work correctly on Safari 11

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1179,16 +1179,9 @@
 
         _getSingleFileInputFiles: function (fileInput) {
             fileInput = $(fileInput);
-            var entries = fileInput.prop('webkitEntries') ||
-                    fileInput.prop('entries'),
-                files,
-                value;
-            if (entries && entries.length) {
-                return this._handleFileTreeEntries(entries);
-            }
-            files = $.makeArray(fileInput.prop('files'));
+            var files = $.makeArray(fileInput.prop('files'));
             if (!files.length) {
-                value = fileInput.prop('value');
+                var value = fileInput.prop('value');
                 if (!value) {
                     return $.Deferred().resolve([]).promise();
                 }

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1179,8 +1179,10 @@
 
         _getSingleFileInputFiles: function (fileInput) {
             fileInput = $(fileInput);
-            var entries = fileInput.prop('webkitEntries') ||
-                    fileInput.prop('entries'),
+            
+            // FileSystemEntries doesn't seem to work correctly on Safari
+            // See https://stackoverflow.com/questions/49918319/jquery-file-upload-cannot-upload-file-in-safari-11
+            var entries = fileInput.prop('webkitEntries') || fileInput.prop('entries'),
                 files,
                 value;
             if (entries && entries.length) {

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1144,10 +1144,10 @@
                 $.map(entries, function (entry) {
                     return that._handleFileTreeEntry(entry, path);
                 })
-            ).then(function () {
+            ).then(function (entries) {
                 return Array.prototype.concat.apply(
                     [],
-                    arguments
+                    entries
                 );
             });
         },
@@ -1213,10 +1213,10 @@
             return $.when.apply(
                 $,
                 $.map(fileInput, this._getSingleFileInputFiles)
-            ).then(function () {
+            ).then(function (files) {
                 return Array.prototype.concat.apply(
                     [],
-                    arguments
+                    files
                 );
             });
         },

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1180,8 +1180,6 @@
         _getSingleFileInputFiles: function (fileInput) {
             fileInput = $(fileInput);
             
-            // FileSystemEntries doesn't seem to work correctly on Safari
-            // See https://stackoverflow.com/questions/49918319/jquery-file-upload-cannot-upload-file-in-safari-11
             var entries = fileInput.prop('webkitEntries') || fileInput.prop('entries'),
                 files,
                 value;
@@ -1230,7 +1228,7 @@
                     form: $(e.target.form)
                 };
             this._getFileInputFiles(data.fileInput).always(function (files) {
-                data.files = files;
+                data.files = $.makeArray(files);
                 if (that.options.replaceFileInput) {
                     that._replaceFileInput(data);
                 }

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1179,9 +1179,8 @@
 
         _getSingleFileInputFiles: function (fileInput) {
             fileInput = $(fileInput);
-            
             var entries = fileInput.prop('webkitEntries') ||
-                fileInput.prop('entries'),
+                    fileInput.prop('entries'),
                 files,
                 value;
             if (entries && entries.length) {

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1180,7 +1180,8 @@
         _getSingleFileInputFiles: function (fileInput) {
             fileInput = $(fileInput);
             
-            var entries = fileInput.prop('webkitEntries') || fileInput.prop('entries'),
+            var entries = fileInput.prop('webkitEntries') ||
+                fileInput.prop('entries'),
                 files,
                 value;
             if (entries && entries.length) {


### PR DESCRIPTION
I created this PR to start a discussion about reading files from file input. There are situations, where upload using Safari 11 fails, because of the data provided by function `_getSingleFileInputFiles`.

I'm debugging minified version of my app on remote env (on local env everything works file) and, as you can see below, `_onAdd` function is being called with a single file, instead of array of files (property called `files`):
![image](https://user-images.githubusercontent.com/6187417/42996300-6dd68e30-8c13-11e8-9fb5-9c87462d357f.png)

As a result, further execution of this function if being canceled because `_onAdd` expects to see array - otherwise, upload fails:
![image](https://user-images.githubusercontent.com/6187417/42996266-522ef3de-8c13-11e8-82f6-fb6185b3a9b9.png)

More detailed description of this issue can be found here - https://stackoverflow.com/questions/49918319/jquery-file-upload-cannot-upload-file-in-safari-11
