### PR TITLE
[Security] Add SRI to external JavaScript

### DIFF
--- a/angularjs.html
+++ b/angularjs.html
@@ -177,18 +177,18 @@
     <a class="play-pause"></a>
     <ol class="indicator"></ol>
 </div>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js" integrity="sha384-r6jjWwxAypHaESwS5an5J9dkfzwQuKVNV9FZM9B6fnt8PFuY0cVwLhV7BltCZhLy" crossorigin="anonymous"></script>
 <!-- The jQuery UI widget factory, can be omitted if jQuery UI is already included -->
 <script src="js/vendor/jquery.ui.widget.js"></script>
 <!-- The Load Image plugin is included for the preview images and image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js" integrity="sha384-klGuZWTnqB7v2Zy+LDefVRiFX90fVhu5XSs58OioYvF7nGVV4VP91dbUr5e5u4np" crossorigin="anonymous"></script>
 <!-- The Canvas to Blob plugin is included for image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js" integrity="sha384-Ruiok12tfp1D6SJw02NyOhoEKZ1oyXvy4/0YfF+K459YJA31h93bS+iOszDHXd8w" crossorigin="anonymous"></script>
 <!-- Bootstrap JS is not required, but included for the responsive demo navigation -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <!-- blueimp Gallery script -->
-<script src="https://blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js"></script>
+<script src="https://blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js" integrity="sha384-dCF25SRAwEga8+EATJhluXfC+zve4mtBr9kaZ6rlp0xYbi9zR8PzN29hje8I9L9t" crossorigin="anonymous"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->
 <script src="js/jquery.iframe-transport.js"></script>
 <!-- The basic File Upload plugin -->

--- a/basic-plus.html
+++ b/basic-plus.html
@@ -96,15 +96,15 @@
         </div>
     </div>
 </div>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
 <!-- The jQuery UI widget factory, can be omitted if jQuery UI is already included -->
 <script src="js/vendor/jquery.ui.widget.js"></script>
 <!-- The Load Image plugin is included for the preview images and image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js" integrity="sha384-klGuZWTnqB7v2Zy+LDefVRiFX90fVhu5XSs58OioYvF7nGVV4VP91dbUr5e5u4np" crossorigin="anonymous"></script> 
 <!-- The Canvas to Blob plugin is included for image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js" integrity="sha384-Ruiok12tfp1D6SJw02NyOhoEKZ1oyXvy4/0YfF+K459YJA31h93bS+iOszDHXd8w" crossorigin="anonymous"></script>
 <!-- Bootstrap JS is not required, but included for the responsive demo navigation -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->
 <script src="js/jquery.iframe-transport.js"></script>
 <!-- The basic File Upload plugin -->

--- a/basic.html
+++ b/basic.html
@@ -96,7 +96,7 @@
         </div>
     </div>
 </div>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
 <!-- The jQuery UI widget factory, can be omitted if jQuery UI is already included -->
 <script src="js/vendor/jquery.ui.widget.js"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->
@@ -104,7 +104,7 @@
 <!-- The basic File Upload plugin -->
 <script src="js/jquery.fileupload.js"></script>
 <!-- Bootstrap JS is not required, but included for the responsive demo navigation -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <script>
 /*jslint unparam: true */
 /*global window, $ */

--- a/cors/postmessage.html
+++ b/cors/postmessage.html
@@ -15,7 +15,7 @@
 <head>
 <meta charset="utf-8">
 <title>jQuery File Upload Plugin postMessage API</title>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
 </head>
 <body>
 <script>

--- a/index.html
+++ b/index.html
@@ -216,19 +216,19 @@
     </tr>
 {% } %}
 </script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script> 
 <!-- The jQuery UI widget factory, can be omitted if jQuery UI is already included -->
 <script src="js/vendor/jquery.ui.widget.js"></script>
 <!-- The Templates plugin is included to render the upload/download listings -->
-<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js" integrity="sha384-9RnDvEg3yE0DwTGAY34Gze15jSzmr6XlrL5t/fzE2+qNe93kv6fyr3BOAsJIu8yL" crossorigin="anonymous"></script>
 <!-- The Load Image plugin is included for the preview images and image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js" integrity="sha384-klGuZWTnqB7v2Zy+LDefVRiFX90fVhu5XSs58OioYvF7nGVV4VP91dbUr5e5u4np" crossorigin="anonymous"></script>
 <!-- The Canvas to Blob plugin is included for image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js" integrity="sha384-Ruiok12tfp1D6SJw02NyOhoEKZ1oyXvy4/0YfF+K459YJA31h93bS+iOszDHXd8w" crossorigin="anonymous"></script>
 <!-- Bootstrap JS is not required, but included for the responsive demo navigation -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <!-- blueimp Gallery script -->
-<script src="https://blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js"></script>
+<script src="https://blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js" integrity="sha384-dCF25SRAwEga8+EATJhluXfC+zve4mtBr9kaZ6rlp0xYbi9zR8PzN29hje8I9L9t" crossorigin="anonymous"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->
 <script src="js/jquery.iframe-transport.js"></script>
 <!-- The basic File Upload plugin -->

--- a/jquery-ui.html
+++ b/jquery-ui.html
@@ -201,16 +201,16 @@
     </tr>
 {% } %}
 </script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
 <!-- The Templates plugin is included to render the upload/download listings -->
-<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js" integrity="sha384-9RnDvEg3yE0DwTGAY34Gze15jSzmr6XlrL5t/fzE2+qNe93kv6fyr3BOAsJIu8yL" crossorigin="anonymous"></script>
 <!-- The Load Image plugin is included for the preview images and image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js" integrity="sha384-klGuZWTnqB7v2Zy+LDefVRiFX90fVhu5XSs58OioYvF7nGVV4VP91dbUr5e5u4np" crossorigin="anonymous"></script>
 <!-- The Canvas to Blob plugin is included for image resizing functionality -->
-<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js" integrity="sha384-Ruiok12tfp1D6SJw02NyOhoEKZ1oyXvy4/0YfF+K459YJA31h93bS+iOszDHXd8w" crossorigin="anonymous"></script>
 <!-- blueimp Gallery script -->
-<script src="https://blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js"></script>
+<script src="https://blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js" integrity="sha384-dCF25SRAwEga8+EATJhluXfC+zve4mtBr9kaZ6rlp0xYbi9zR8PzN29hje8I9L9t" crossorigin="anonymous"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->
 <script src="js/jquery.iframe-transport.js"></script>
 <!-- The basic File Upload plugin -->

--- a/test/index.html
+++ b/test/index.html
@@ -145,11 +145,11 @@
     </tr>
 {% } %}
 </script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
 <script src="../js/vendor/jquery.ui.widget.js"></script>
-<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js"></script>
-<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js"></script>
-<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js" integrity="sha384-9RnDvEg3yE0DwTGAY34Gze15jSzmr6XlrL5t/fzE2+qNe93kv6fyr3BOAsJIu8yL" crossorigin="anonymous"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.all.min.js" integrity="sha384-klGuZWTnqB7v2Zy+LDefVRiFX90fVhu5XSs58OioYvF7nGVV4VP91dbUr5e5u4np" crossorigin="anonymous"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js" integrity="sha384-Ruiok12tfp1D6SJw02NyOhoEKZ1oyXvy4/0YfF+K459YJA31h93bS+iOszDHXd8w" crossorigin="anonymous"></script>
 <script src="../js/jquery.iframe-transport.js"></script>
 <script src="../js/jquery.fileupload.js"></script>
 <script>
@@ -166,7 +166,7 @@ window.testBasicWidget = $.blueimp.fileupload;
 /* global window, $ */
 window.testUIWidget = $.blueimp.fileupload;
 </script>
-<script src="https://code.jquery.com/qunit/qunit-1.23.1.js"></script>
+<script src="https://code.jquery.com/qunit/qunit-1.23.1.js" integrity="sha384-FJbPWND3tHbuhP8PhCp3Kn0bEtCxaIq+sfkmiJ+Su0jchKFnVbPQTTyPiuwqbkXa" crossorigin="anonymous"></script>
 <script src="test.js"></script>
 </body>
 </html>


### PR DESCRIPTION
SubResource Integrity protects users from malicious changes to external JavaScript libraries.

This PR adds SRI to every `<script src="https://`

See

* https://www.srihash.org/
* https://www.w3.org/TR/SRI/

And for a practical example of why this is necessary:
* https://scotthelme.co.uk/hardening-payment-forms-with-csp/