### PR TITLE
Remove "protected" visibility modifier from const

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -38,9 +38,9 @@ class UploadHandler
         'image_resize' => 'Failed to resize image'
     );
 
-    protected const IMAGETYPE_GIF = 1;
-    protected const IMAGETYPE_JPEG = 2;
-    protected const IMAGETYPE_PNG = 3;
+    const IMAGETYPE_GIF = 1;
+    const IMAGETYPE_JPEG = 2;
+    const IMAGETYPE_PNG = 3;
 
     protected $image_objects = array();
 


### PR DESCRIPTION
This restores compatibility with PHP 5.6 and PHP 7.0.

I'm not sure whether you actually care much about this, as PHP 5.6 reaches end of life in less than two months (and PHP 7.0 in less than one month), but it was working in PHP 5.6 before these `protected` constants were added.

http://php.net/manual/en/migration71.new-features.php#migration71.new-features.class-constant-visibility