### PR TITLE
Initialization on input element for use in jQuery-UI fails

### DIFF
--- a/js/jquery.fileupload-jquery-ui.js
+++ b/js/jquery.fileupload-jquery-ui.js
@@ -50,7 +50,7 @@
             },
             progressall: function (e, data) {
                 var $this = $(this);
-                $this.find('.fileupload-progress')
+                $this.closest('.fileupload-buttonbar').find('.fileupload-progress')
                     .find('.progress').progressbar(
                         'option',
                         'value',
@@ -120,8 +120,8 @@
 
         _create: function () {
             this._super();
-            this.element
-                .find('.fileupload-buttonbar')
+            this.options.fileInput
+                .closest('.fileupload-buttonbar')
                 .find('.fileinput-button').each(function () {
                     var input = $(this).find('input:file').detach();
                     $(this)
@@ -138,8 +138,8 @@
         },
 
         _destroy: function () {
-            this.element
-                .find('.fileupload-buttonbar')
+            this.options.fileInput
+                .closest('.fileupload-buttonbar')
                 .find('.fileinput-button').each(function () {
                     var input = $(this).find('input:file').detach();
                     $(this)

--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -302,7 +302,7 @@
                 }
                 var $this = $(this),
                     progress = Math.floor(data.loaded / data.total * 100),
-                    globalProgressNode = $this.find('.fileupload-progress'),
+                    globalProgressNode = $this.closest('.fileupload-buttonbar').find('.fileupload-progress'),
                     extendedProgressNode = globalProgressNode
                         .find('.progress-extended');
                 if (extendedProgressNode.length) {
@@ -327,7 +327,7 @@
                 var that = $(this).data('blueimp-fileupload') ||
                         $(this).data('fileupload');
                 that._resetFinishedDeferreds();
-                that._transition($(this).find('.fileupload-progress')).done(
+                that._transition($(this).closest('.fileupload-buttonbar').find('.fileupload-progress')).done(
                     function () {
                         that._trigger('started', e);
                     }
@@ -345,7 +345,7 @@
                     .done(function () {
                         that._trigger('stopped', e);
                     });
-                that._transition($(this).find('.fileupload-progress')).done(
+                that._transition($(this).closest('.fileupload-buttonbar').find('.fileupload-progress')).done(
                     function () {
                         $(this).find('.progress')
                             .attr('aria-valuenow', '0')
@@ -577,7 +577,7 @@
         },
 
         _initButtonBarEventHandlers: function () {
-            var fileUploadButtonBar = this.element.find('.fileupload-buttonbar'),
+            var fileUploadButtonBar = this.options.fileInput.closest('.fileupload-buttonbar'),
                 filesList = this.options.filesContainer;
             this._on(fileUploadButtonBar.find('.start'), {
                 click: function (e) {
@@ -613,12 +613,12 @@
 
         _destroyButtonBarEventHandlers: function () {
             this._off(
-                this.element.find('.fileupload-buttonbar')
+                this.options.fileInput.closest('.fileupload-buttonbar')
                     .find('.start, .cancel, .delete'),
                 'click'
             );
             this._off(
-                this.element.find('.fileupload-buttonbar .toggle'),
+                this.options.fileInput.closest('.fileupload-buttonbar .toggle'),
                 'change.'
             );
         },
@@ -640,13 +640,13 @@
         },
 
         _enableFileInputButton: function () {
-            this.element.find('.fileinput-button input')
+            this.options.fileInput.closest('.fileupload-buttonbar').find('.fileinput-button input')
                 .prop('disabled', false)
                 .parent().removeClass('disabled');
         },
 
         _disableFileInputButton: function () {
-            this.element.find('.fileinput-button input')
+            this.options.fileInput.closest('.fileupload-buttonbar').find('.fileinput-button input')
                 .prop('disabled', true)
                 .parent().addClass('disabled');
         },
@@ -669,7 +669,7 @@
         _initFilesContainer: function () {
             var options = this.options;
             if (options.filesContainer === undefined) {
-                options.filesContainer = this.element.find('.files');
+                options.filesContainer = this.options.fileInput.closest('.fileupload-buttonbar').find('.files');
             } else if (!(options.filesContainer instanceof $)) {
                 options.filesContainer = $(options.filesContainer);
             }
@@ -696,14 +696,14 @@
             }
             this._super();
             if (wasDisabled) {
-                this.element.find('input, button').prop('disabled', false);
+                this.options.fileInput.closest('.fileupload-buttonbar').find('input, button').prop('disabled', false);
                 this._enableFileInputButton();
             }
         },
 
         disable: function () {
             if (!this.options.disabled) {
-                this.element.find('input, button').prop('disabled', true);
+                this.options.fileInput.closest('.fileupload-buttonbar').find('input, button').prop('disabled', true);
                 this._disableFileInputButton();
             }
             this._super();


### PR DESCRIPTION
Extension for use in JQuery-UI had an issue when fileupload was
initialized on the input type=file element directly rather than on the
form.
In fact use of `this.element´ had to be replaced by a higher level in
DOM so we can .find() it always.
So I replaced the element by the fileInput.