### PR TITLE
make basic-plus.html show correct UI when singleFileUploads is false

### DIFF
--- a/basic-plus.html
+++ b/basic-plus.html
@@ -162,14 +162,14 @@ $(function () {
     }).on('fileuploadadd', function (e, data) {
         data.context = $('<div/>').appendTo('#files');
         $.each(data.files, function (index, file) {
-            var node = $('<p/>')
-                    .append($('<span/>').text(file.name));
-            if (!index) {
-                node
-                    .append('<br>')
-                    .append(uploadButton.clone(true).data(data));
+            $('<p/>')
+                .append($('<span/>').text(file.name))
+                .appendTo(data.context);
+            if (index === data.files.length - 1) {
+                $('<p/>')
+                    .append(uploadButton.clone(true).data(data))
+                    .appendTo(data.context);
             }
-            node.appendTo(data.context);
         });
     }).on('fileuploadprocessalways', function (e, data) {
         var index = data.index,


### PR DESCRIPTION
Currently when we set the option singleFileUploads to false, the UI for basic-plus.html looks weird.
For example, when I upload three image at once, then I got the following UI. The upload button does not locate at the bottom of the div element.
![image](https://user-images.githubusercontent.com/3004057/60341009-b67e5480-99df-11e9-91c2-9958d527ee65.png)

I have tried to make the UI work with the correct behavior
![image](https://user-images.githubusercontent.com/3004057/60341218-5d62f080-99e0-11e9-9c08-60900715167b.png)
