### PR TITLE
Fixes bind and unbind warnings from jQuery migrate version 3.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 .DS_Store
 *.pyc
 node_modules
+
+\.idea/inspectionProfiles/Project_Default\.xml
+
+\.idea/jQuery-File-Upload\.iml
+
+\.idea/jsLinters/jshint\.xml
+
+\.idea/misc\.xml
+
+\.idea/modules\.xml
+
+\.idea/vcs\.xml
+
+\.idea/workspace\.xml

--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
   "bugs": "https://github.com/blueimp/jQuery-File-Upload/issues",
   "license": "MIT",
   "dependencies": {
-    "jquery": ">=1.6",
+    "jquery": ">=1.7",
     "blueimp-tmpl": ">=2.5.4",
     "blueimp-load-image": ">=1.13.0",
     "blueimp-canvas-to-blob": ">=2.1.1"

--- a/js/cors/jquery.postmessage-transport.js
+++ b/js/cors/jquery.postmessage-transport.js
@@ -104,7 +104,7 @@
                                         data.headers
                                     );
                                     iframe.remove();
-                                    $(window).unbind(eventName);
+                                    $(window).off(eventName);
                                 }
                             }
                         });

--- a/js/cors/jquery.postmessage-transport.js
+++ b/js/cors/jquery.postmessage-transport.js
@@ -81,12 +81,12 @@
                         '<iframe style="display:none;" src="' +
                             options.postMessage + '" name="' +
                             message.id + '"></iframe>'
-                    ).bind('load', function () {
+                    ).on('load', function () {
                         $.each(names, function (i, name) {
                             message[name] = options[name];
                         });
                         message.dataType = message.dataType.replace('postmessage ', '');
-                        $(window).bind(eventName, function (e) {
+                        $(window).on(eventName, function (e) {
                             e = e.originalEvent;
                             var data = e.data,
                                 ev;

--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -416,7 +416,7 @@
                 url = link.prop('href'),
                 name = link.prop('download'),
                 type = 'application/octet-stream';
-            link.bind('dragstart', function (e) {
+            link.on('dragstart', function (e) {
                 try {
                     e.originalEvent.dataTransfer.setData(
                         'DownloadURL',
@@ -558,7 +558,7 @@
         _transition: function (node) {
             var dfd = $.Deferred();
             if ($.support.transition && node.hasClass('fade') && node.is(':visible')) {
-                node.bind(
+                node.on(
                     $.support.transition.end,
                     function (e) {
                         // Make sure we don't respond to other transitions events

--- a/js/jquery.fileupload-ui.js
+++ b/js/jquery.fileupload-ui.js
@@ -564,7 +564,7 @@
                         // Make sure we don't respond to other transitions events
                         // in the container element, e.g. from button elements:
                         if (e.target === node[0]) {
-                            node.unbind($.support.transition.end);
+                            node.off($.support.transition.end);
                             dfd.resolveWith(node);
                         }
                     }

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -212,7 +212,7 @@
             // and allows you to override plugin options as well as define ajax settings.
             //
             // Listeners for this callback can also be bound the following way:
-            // .bind('fileuploadadd', func);
+            // .on('fileuploadadd', func);
             //
             // data.submit() returns a Promise object and allows to attach additional
             // handlers using jQuery's Deferred callbacks:
@@ -232,58 +232,58 @@
             // Other callbacks:
 
             // Callback for the submit event of each file upload:
-            // submit: function (e, data) {}, // .bind('fileuploadsubmit', func);
+            // submit: function (e, data) {}, // .on('fileuploadsubmit', func);
 
             // Callback for the start of each file upload request:
-            // send: function (e, data) {}, // .bind('fileuploadsend', func);
+            // send: function (e, data) {}, // .on('fileuploadsend', func);
 
             // Callback for successful uploads:
-            // done: function (e, data) {}, // .bind('fileuploaddone', func);
+            // done: function (e, data) {}, // .on('fileuploaddone', func);
 
             // Callback for failed (abort or error) uploads:
-            // fail: function (e, data) {}, // .bind('fileuploadfail', func);
+            // fail: function (e, data) {}, // .on('fileuploadfail', func);
 
             // Callback for completed (success, abort or error) requests:
-            // always: function (e, data) {}, // .bind('fileuploadalways', func);
+            // always: function (e, data) {}, // .on('fileuploadalways', func);
 
             // Callback for upload progress events:
-            // progress: function (e, data) {}, // .bind('fileuploadprogress', func);
+            // progress: function (e, data) {}, // .on('fileuploadprogress', func);
 
             // Callback for global upload progress events:
-            // progressall: function (e, data) {}, // .bind('fileuploadprogressall', func);
+            // progressall: function (e, data) {}, // .on('fileuploadprogressall', func);
 
             // Callback for uploads start, equivalent to the global ajaxStart event:
-            // start: function (e) {}, // .bind('fileuploadstart', func);
+            // start: function (e) {}, // .on('fileuploadstart', func);
 
             // Callback for uploads stop, equivalent to the global ajaxStop event:
-            // stop: function (e) {}, // .bind('fileuploadstop', func);
+            // stop: function (e) {}, // .on('fileuploadstop', func);
 
             // Callback for change events of the fileInput(s):
-            // change: function (e, data) {}, // .bind('fileuploadchange', func);
+            // change: function (e, data) {}, // .on('fileuploadchange', func);
 
             // Callback for paste events to the pasteZone(s):
-            // paste: function (e, data) {}, // .bind('fileuploadpaste', func);
+            // paste: function (e, data) {}, // .on('fileuploadpaste', func);
 
             // Callback for drop events of the dropZone(s):
-            // drop: function (e, data) {}, // .bind('fileuploaddrop', func);
+            // drop: function (e, data) {}, // .on('fileuploaddrop', func);
 
             // Callback for dragover events of the dropZone(s):
-            // dragover: function (e) {}, // .bind('fileuploaddragover', func);
+            // dragover: function (e) {}, // .on('fileuploaddragover', func);
 
             // Callback before the start of each chunk upload request (before form data initialization):
-            // chunkbeforesend: function (e, data) {}, // .bind('fileuploadchunkbeforesend', func);
+            // chunkbeforesend: function (e, data) {}, // .on('fileuploadchunkbeforesend', func);
 
             // Callback for the start of each chunk upload request:
-            // chunksend: function (e, data) {}, // .bind('fileuploadchunksend', func);
+            // chunksend: function (e, data) {}, // .on('fileuploadchunksend', func);
 
             // Callback for successful chunk uploads:
-            // chunkdone: function (e, data) {}, // .bind('fileuploadchunkdone', func);
+            // chunkdone: function (e, data) {}, // .on('fileuploadchunkdone', func);
 
             // Callback for failed (abort or error) chunk uploads:
-            // chunkfail: function (e, data) {}, // .bind('fileuploadchunkfail', func);
+            // chunkfail: function (e, data) {}, // .on('fileuploadchunkfail', func);
 
             // Callback for completed (success, abort or error) chunk upload requests:
-            // chunkalways: function (e, data) {}, // .bind('fileuploadchunkalways', func);
+            // chunkalways: function (e, data) {}, // .on('fileuploadchunkalways', func);
 
             // The plugin options are used as settings object for the ajax calls.
             // The following are jQuery ajax settings required for the file uploads:
@@ -432,7 +432,7 @@
             // Accesss to the native XHR object is required to add event listeners
             // for the upload progress event:
             if (xhr.upload) {
-                $(xhr.upload).bind('progress', function (e) {
+                $(xhr.upload).on('progress', function (e) {
                     var oe = e.originalEvent;
                     // Make sure the progress event properties get copied over:
                     e.lengthComputable = oe.lengthComputable;

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -449,7 +449,7 @@
         _deinitProgressListener: function (options) {
             var xhr = options.xhr ? options.xhr() : $.ajaxSettings.xhr();
             if (xhr.upload) {
-                $(xhr.upload).unbind('progress');
+                $(xhr.upload).off('progress');
             }
         },
 
@@ -1113,7 +1113,7 @@
                 inputClone.focus();
             }
             // Avoid memory leaks with the detached file input:
-            $.cleanData(input.unbind('remove'));
+            $.cleanData(input.off('remove'));
             // Replace the original file input element in the fileInput
             // elements set with the clone, which has been copied including
             // event handlers:

--- a/js/jquery.iframe-transport.js
+++ b/js/jquery.iframe-transport.js
@@ -79,13 +79,13 @@
                     iframe = $(
                         '<iframe src="' + initialIframeSrc +
                             '" name="iframe-transport-' + counter + '"></iframe>'
-                    ).bind('load', function () {
+                    ).on('load', function () {
                         var fileInputClones,
                             paramNames = $.isArray(options.paramName) ?
                                     options.paramName : [options.paramName];
                         iframe
                             .off('load')
-                            .bind('load', function () {
+                            .on('load', function () {
                                 var response;
                                 // Wrap in a try/catch block to catch exceptions thrown
                                 // when trying to access cross-domain iframe contents:

--- a/js/jquery.iframe-transport.js
+++ b/js/jquery.iframe-transport.js
@@ -84,7 +84,7 @@
                             paramNames = $.isArray(options.paramName) ?
                                     options.paramName : [options.paramName];
                         iframe
-                            .unbind('load')
+                            .off('load')
                             .bind('load', function () {
                                 var response;
                                 // Wrap in a try/catch block to catch exceptions thrown
@@ -177,7 +177,7 @@
                         // and prevents warning popups on HTTPS in IE6.
                         // concat is used to avoid the "Script URL" JSLint error:
                         iframe
-                            .unbind('load')
+                            .off('load')
                             .prop('src', initialIframeSrc);
                     }
                     if (form) {


### PR DESCRIPTION
Start supporting jQuery 3 syntax updates.

- Fixes [deprecated `unbind` method](https://api.jquery.com/unbind/#unbind-eventType-handler) by replacing it with `off` syntax [described in jQuery migrate warnings.md](https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnbind-is-deprecated).
- Fixes [deprecated `bind` method](https://api.jquery.com/bind/#bind-eventType-eventData-handler) by replacing it with `on` syntax [described in jQuery migrate warnings.md](https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnbind-is-deprecated).

:warning:  **Heads Up**, this drops support for jQuery versions before 1.7 as `.on` and `.off` were [introduced in that version](https://api.jquery.com/category/version/1.7/).