### PR TITLE
Compatibility with jQuery 3.5.0

### DIFF
--- a/js/cors/jquery.postmessage-transport.js
+++ b/js/cors/jquery.postmessage-transport.js
@@ -61,7 +61,7 @@
   $.ajaxTransport('postmessage', function (options) {
     if (options.postMessage && window.postMessage) {
       var iframe,
-        loc = $('<a>').prop('href', options.postMessage)[0],
+        loc = $('<a></a>').prop('href', options.postMessage)[0],
         target = loc.protocol + '//' + loc.host,
         xhrUpload = options.xhr().upload;
       // IE always includes the port for the host property of a link

--- a/js/demo.js
+++ b/js/demo.js
@@ -47,7 +47,7 @@ $(function () {
         url: '//jquery-file-upload.appspot.com/',
         type: 'HEAD'
       }).fail(function () {
-        $('<div class="alert alert-danger"/>')
+        $('<div class="alert alert-danger"></div>')
           .text('Upload server currently unavailable - ' + new Date())
           .appendTo('#fileupload');
       });


### PR DESCRIPTION
Usages like `$('<div/>')` must be changed to `$('<div></div>')`

See the blog post:
https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/
and the upgrade guide for more details:
https://jquery.com/upgrade-guide/3.5/