### PR TITLE
docs: Fix simple typo, numer -> number

### DIFF
--- a/test/vendor/mocha.js
+++ b/test/vendor/mocha.js
@@ -8144,7 +8144,7 @@ exports.isPromise = function isPromise(value) {
  * Clamps a numeric value to an inclusive range.
  *
  * @param {number} value - Value to be clamped.
- * @param {numer[]} range - Two element array specifying [min, max] range.
+ * @param {number[]} range - Two element array specifying [min, max] range.
  * @returns {number} clamped value
  */
 exports.clamp = function clamp(value, range) {


### PR DESCRIPTION
There is a small typo in test/vendor/mocha.js.

Should read `number` rather than `numer`.

