### PR TITLE
Update jquery.fileupload.js

### DIFF
--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -1298,8 +1298,7 @@
     _getSingleFileInputFiles: function (fileInput) {
       // eslint-disable-next-line no-param-reassign
       fileInput = $(fileInput);
-      var entries =
-          fileInput.prop('webkitEntries') || fileInput.prop('entries'),
+      var entries = fileInput.prop('entries'),
         files,
         value;
       if (entries && entries.length) {


### PR DESCRIPTION
This code creates issues with multiple file attachments with ios. only the first attachment works, subsequent attachment fails.
HTMLInputElement.webkitEntries api  for input file element, is highly inconsistent in nature. web documents suggests that webkitEntries is non-standard and experimental api and support for it has been dropped.