### PR TITLE
Fix spelling mistakes/typos found by CodeSpell 2.1.0

### DIFF
--- a/js/jquery.fileupload-process.js
+++ b/js/jquery.fileupload-process.js
@@ -120,7 +120,7 @@
       options.processQueue = processQueue;
     },
 
-    // Returns the number of files currently in the processsing queue:
+    // Returns the number of files currently in the processing queue:
     processing: function () {
       return this._processing;
     },

--- a/js/jquery.fileupload-validate.js
+++ b/js/jquery.fileupload-validate.js
@@ -57,7 +57,7 @@
             */
 
       // Function returning the current number of files,
-      // has to be overriden for maxNumberOfFiles validation:
+      // has to be overridden for maxNumberOfFiles validation:
       getNumberOfFiles: $.noop,
 
       // Error and info messages:

--- a/js/jquery.fileupload.js
+++ b/js/jquery.fileupload.js
@@ -455,7 +455,7 @@
     _initProgressListener: function (options) {
       var that = this,
         xhr = options.xhr ? options.xhr() : $.ajaxSettings.xhr();
-      // Accesss to the native XHR object is required to add event listeners
+      // Access to the native XHR object is required to add event listeners
       // for the upload progress event:
       if (xhr.upload) {
         $(xhr.upload).on('progress', function (e) {
@@ -1172,7 +1172,7 @@
       data.fileInputClone = inputClone;
       $('<form></form>').append(inputClone)[0].reset();
       // Detaching allows to insert the fileInput on another form
-      // without loosing the file input value:
+      // without losing the file input value:
       input.after(inputClone).detach();
       // If the fileInput had focus before it was detached,
       // restore focus to the inputClone.

--- a/test/vendor/chai.js
+++ b/test/vendor/chai.js
@@ -305,7 +305,7 @@ module.exports = {
    *
    * Set it to zero if you want to disable truncating altogether.
    *
-   * This is especially userful when doing assertions on arrays: having this
+   * This is especially useful when doing assertions on arrays: having this
    * set to a reasonable large value makes the failure messages readily
    * inspectable.
    *

--- a/test/vendor/mocha.js
+++ b/test/vendor/mocha.js
@@ -1980,7 +1980,7 @@ Mocha.prototype.global = function(global) {
     });
   return this;
 };
-// for backwards compability, 'globals' is an alias of 'global'
+// for backwards compatibility, 'globals' is an alias of 'global'
 Mocha.prototype.globals = Mocha.prototype.global;
 
 /**
@@ -2170,7 +2170,7 @@ Mocha.prototype.enableTimeouts = function(enableTimeouts) {
  *
  * @public
  * @see [CLI option](../#-async-only-a)
- * @param {boolean} [asyncOnly=true] - Wether to force `done` callback or promise.
+ * @param {boolean} [asyncOnly=true] - Whether to force `done` callback or promise.
  * @return {Mocha} this
  * @chainable
  */
@@ -8677,7 +8677,7 @@ function alloc (size, fill, encoding) {
   if (fill !== undefined) {
     // Only pay attention to encoding if it's a string. This
     // prevents accidentally sending in a number that would
-    // be interpretted as a start offset.
+    // be interpreted as a start offset.
     return typeof encoding === 'string'
       ? createBuffer(size).fill(fill, encoding)
       : createBuffer(size).fill(fill)
@@ -8969,7 +8969,7 @@ function slowToString (encoding, start, end) {
     return ''
   }
 
-  // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
+  // Force coercion to uint32. This will also coerce falsey/NaN values to 0.
   end >>>= 0
   start >>>= 0
 
@@ -14499,7 +14499,7 @@ function defaultClearTimeout () {
 } ())
 function runTimeout(fun) {
     if (cachedSetTimeout === setTimeout) {
-        //normal enviroments in sane situations
+        //normal environments in sane situations
         return setTimeout(fun, 0);
     }
     // if setTimeout wasn't available but was latter defined
@@ -14508,14 +14508,14 @@ function runTimeout(fun) {
         return setTimeout(fun, 0);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedSetTimeout(fun, 0);
     } catch(e){
         try {
             // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
             return cachedSetTimeout.call(null, fun, 0);
         } catch(e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopefully our context correct otherwise it will throw a global error
             return cachedSetTimeout.call(this, fun, 0);
         }
     }
@@ -14524,7 +14524,7 @@ function runTimeout(fun) {
 }
 function runClearTimeout(marker) {
     if (cachedClearTimeout === clearTimeout) {
-        //normal enviroments in sane situations
+        //normal environments in sane situations
         return clearTimeout(marker);
     }
     // if clearTimeout wasn't available but was latter defined
@@ -14533,14 +14533,14 @@ function runClearTimeout(marker) {
         return clearTimeout(marker);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedClearTimeout(marker);
     } catch (e){
         try {
             // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
             return cachedClearTimeout.call(null, marker);
         } catch (e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopefully our context correct otherwise it will throw a global error.
             // Some versions of I.E. have different rules for clearTimeout vs setTimeout
             return cachedClearTimeout.call(this, marker);
         }
@@ -14606,7 +14606,7 @@ process.nextTick = function (fun) {
     }
 };
 
-// v8 likes predictible objects
+// v8 likes predictable objects
 function Item(fun, array) {
     this.fun = fun;
     this.array = array;
@@ -17697,7 +17697,7 @@ exports.debuglog = function(set) {
 
 
 /**
- * Echos the value of a value. Trys to print the value out
+ * Echos the value of a value. Tries to print the value out
  * in the best way possible given the different types.
  *
  * @param {Object} obj The object to print out.


### PR DESCRIPTION
CodeSpell 2.1.0 found some spelling mistakes/typos, which I have corrected in this pull request.  They are all changes to comments.

CodeSpell is a free, open source tool for finding common English misspellings and typographic errors in source code. Information about it can be found here: [CodeSpell on GitHub](https://github.com/codespell-project/codespell)
